### PR TITLE
Allow GitHub token to be specified as an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ $ <newline_separated_list_of_repositories> | ./bin/ebi.js <command>
 
 ### Examples
 
+Prerequisites
+
+-   [Setting up your GitHub personal access token](#setting-up-your-github-personal-access-token)
+
 Show help
 
     ./bin/ebi.js --help
@@ -25,7 +29,7 @@ Show help
 Determine whether a repo has a `Procfile`
 
 ```
-$ echo -e "Financial-Times/next-search-page\nFinancial-Times/next-gdpr-tests" | ./bin/ebi.js --token $GITHUB_PERSONAL_ACCESS_TOKEN contents Procfile
+$ echo -e "Financial-Times/next-search-page\nFinancial-Times/next-gdpr-tests" | ./bin/ebi.js contents Procfile
 Financial-Times/next-search-page
 404 ERROR: file 'Procfile' not found in 'Financial-Times/next-gdpr-tests'
 ```
@@ -33,33 +37,21 @@ Financial-Times/next-search-page
 Find all the `node` engines and their versions in `package.json`
 
 ```
-echo -e "Financial-Times/next-search-page\nFinancial-Times/next-gdpr-tests" | ./bin/ebi.js --token $GITHUB_PERSONAL_ACCESS_TOKEN package:engines
+echo -e "Financial-Times/next-search-page\nFinancial-Times/next-gdpr-tests" | ./bin/ebi.js package:engines
 Financial-Times/next-search-page	node@8.15.0
 Financial-Times/next-gdpr-tests	node@^8.9.4	npm@5.7.1
 ```
 
-## GitHub personal access token security
+## Setting up your GitHub personal access token
 
-This tool requires a [GitHub personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/)
-with all `repo` scopes. This is _very powerful_ as it has access to modify a
-repository's settings, so it is strongly recommended that you store this token
-securely.
+This tool requires a [GitHub personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) with all `repo` scopes. This is _very powerful_ as it has access to modify a repository's settings, so it is strongly recommended that you store this token securely.
 
-Once you have created a [new GitHub personal access token with all `repo` scopes](https://github.com/settings/tokens/new?description=Manage%20GitHub%20Apps%20CLI&scopes=repo 'Click here to create a new GitHub personal access token'),
-you can store it in an environment variable and pass it to `manage-github-apps`
-whenever you run a command that requires the `--token` option:
-
-```sh
---token $GITHUB_PERSONAL_ACCESS_TOKEN
-```
-
-You should avoid passing your GitHub personal access token directly to any CLI
-arguments as then it will be visible in your shell history.
-
-A recommended approach is to store auth tokens in your operating system's
-password management system (e.g. Keychain on macOS), retrieve it in your shell's
-rcfile (e.g. `~/.bashrc`) and assign it to an environment variable so that it is
-available to any shell that you run.
+1. Create a [new GitHub personal access token with all `repo` scopes](https://github.com/settings/tokens/new?description=Ebi%20CLI&scopes=repo)
+2. Store the token in the `GITHUB_PERSONAL_ACCESS_TOKEN` environment variable. You should avoid passing your GitHub personal access token directly to any CLI arguments as it will be visible in your shell history. There are a few options to do this:
+    1. If you work at Financial Times, you can follow the [GitHub personal access token docs](https://github.com/Financial-Times/next/wiki/How-to-store-and-access-a-GitHub-personal-access-token-securely)
+    2. Use your operating system's password management system (e.g. Keychain on macOS) to store and retrieve `GITHUB_PERSONAL_ACCESS_TOKEN` in your shell's rcfile (e.g. `~/.bashrc`), then restart your terminal
+    3. If all else fails, you can set it in your terminal with `GITHUB_PERSONAL_ACCESS_TOKEN=[github-token]`
+    4. If you want use a different token, you can pass in `--token=$GITHUB_PERSONAL_ACCESS_TOKEN` when you run the commands
 
 ## Code formatting with Prettier
 

--- a/src/commands/shared.js
+++ b/src/commands/shared.js
@@ -1,3 +1,5 @@
+const { GITHUB_PERSONAL_ACCESS_TOKEN } = process.env;
+
 const withLimit = yargs => {
 	return yargs.option('limit', {
 		type: 'number',
@@ -7,10 +9,11 @@ const withLimit = yargs => {
 
 const withToken = yargs => {
 	return yargs.option('token', {
-		required: true,
 		type: 'string',
+		// NOTE: Use a function here, so the token is not displayed in the command line
+		default: () => GITHUB_PERSONAL_ACCESS_TOKEN,
 		describe:
-			'GitHub personal access token. Generate one from https://github.com/settings/tokens'
+			'GitHub personal access token (uses `GITHUB_PERSONAL_ACCESS_TOKEN` environment variable by default). Generate one from https://github.com/settings/tokens'
 	});
 };
 


### PR DESCRIPTION
* Get `GITHUB_PERSONAL_ACCESS_TOKEN` as a default value: https://github.com/Financial-Times/ebi/pull/57/commits/dcedb73d51305034c3a2f2a3f443c254301e6469
* Fix up docs: https://github.com/Financial-Times/ebi/pull/57/commits/b44e16c4d9766d1083dc50b692a6701af9d92fae

Fixes https://github.com/Financial-Times/ebi/issues/42