### PR TITLE
Add regex search to all the commands

### DIFF
--- a/lib/object-utils.js
+++ b/lib/object-utils.js
@@ -1,0 +1,34 @@
+const { pick, pickBy, merge } = require('lodash');
+
+const findMatchedKeyPairs = (object, filterFn) => {
+	if (!object) {
+		return;
+	}
+	const matchedKeys = Object.keys(object).filter(filterFn);
+	return pick(object, matchedKeys);
+};
+
+const findMatchedValuePairs = (object, filterFn) => {
+	if (!object) {
+		return;
+	}
+	return pickBy(object, value => {
+		return filterFn(value);
+	});
+};
+
+const findMatchedKeyValuePairs = (object, filterFn) => {
+	if (!object) {
+		return;
+	}
+	return merge(
+		findMatchedKeyPairs(object, filterFn),
+		findMatchedValuePairs(object, filterFn)
+	);
+};
+
+module.exports = {
+	findMatchedKeyPairs,
+	findMatchedValuePairs,
+	findMatchedKeyValuePairs
+};

--- a/src/commands/package-engines.js
+++ b/src/commands/package-engines.js
@@ -1,9 +1,8 @@
 /*eslint no-console: ["error", { allow: ["log", "error"] }] */
-const { pick, pickBy, merge } = require('lodash');
-
 const getContents = require('../../lib/get-contents');
 const getRepositories = require('../../lib/get-repositories');
 const { withToken, withLimit } = require('./shared');
+const { findMatchedKeyValuePairs } = require('../../lib/object-utils');
 
 exports.command = 'package:engines [search]';
 exports.desc = 'Search `engines` field inside the `package.json` file';
@@ -49,15 +48,9 @@ const throwIfNoEngines = ({ filepath, repository }) => (json = {}) => {
 
 const filterSearch = search => engines => {
 	if (search) {
-		const foundKeys = Object.keys(engines).filter(name => {
-			return name.includes(search);
-		});
-		const engineNameSearch = pick(engines, foundKeys);
-		const engineVersionSearch = pickBy(engines, value => {
-			return value.includes(search);
-		});
-
-		return merge(engineNameSearch, engineVersionSearch);
+		return findMatchedKeyValuePairs(engines, value =>
+			value.includes(search)
+		);
 	} else {
 		return engines;
 	}

--- a/src/commands/package.js
+++ b/src/commands/package.js
@@ -1,20 +1,20 @@
 /*eslint no-console: ["error", { allow: ["log", "error"] }] */
 const getContents = require('../../lib/get-contents');
 const getRepositories = require('../../lib/get-repositories');
-const { withToken, withLimit } = require('./shared');
+const { withToken, withLimit, withRegex } = require('./shared');
 
 exports.command = 'package [search]';
 exports.desc = 'Search within the `package.json` file';
 
 exports.builder = yargs => {
-	return withToken(withLimit(yargs)).positional('search', {
+	return withRegex(withToken(withLimit(yargs))).positional('search', {
 		type: 'string',
 		describe: 'What to search for'
 	});
 };
 
 exports.handler = function(argv) {
-	const { token, search, limit } = argv;
+	const { token, search, limit, regex } = argv;
 	const repositories = getRepositories(limit);
 	const filepath = 'package.json';
 
@@ -28,7 +28,18 @@ exports.handler = function(argv) {
 				const noSearch = !search;
 				const containsSearchItem = contents.includes(search);
 
-				if (noSearch || containsSearchItem) {
+				if (regex) {
+					const regExp = new RegExp(regex);
+					const hasMatch = contents.match(regExp);
+
+					if (hasMatch) {
+						return console.log(repository);
+					} else {
+						console.error(
+							`INFO: '${filepath}' has no regex match for '${regExp}' in '${repository}'`
+						);
+					}
+				} else if (noSearch || containsSearchItem) {
 					return console.log(repository);
 				} else {
 					return console.error(

--- a/src/commands/shared.js
+++ b/src/commands/shared.js
@@ -17,4 +17,22 @@ const withToken = yargs => {
 	});
 };
 
-module.exports = { withLimit, withToken };
+const withRegex = yargs => {
+	return yargs
+		.option('regex', {
+			type: 'string',
+			describe: 'Regular expression to search by'
+		})
+		.check(({ regex, search }) => {
+			const regexExists = !!regex;
+			const searchExists = !!search;
+
+			if (regexExists && searchExists) {
+				throw new Error('Only use `search` or `regex`, not both');
+			}
+
+			return true;
+		});
+};
+
+module.exports = { withLimit, withToken, withRegex };

--- a/test/bin/ebi.test.js
+++ b/test/bin/ebi.test.js
@@ -18,4 +18,13 @@ describe('ebi command line', () => {
 			done();
 		});
 	});
+
+	it('throws error if package:engines search has search term and regex', done => {
+		const command =
+			'echo "Financial-Times/ebi" | ./bin/ebi.js package:engines --regex regex-term search-term';
+		exec(command, 'utf8', (err, stdout, stderr) => {
+			expect(stderr).toContain('use `search` or `regex`, not both');
+			done();
+		});
+	});
 });

--- a/test/bin/ebi.test.js
+++ b/test/bin/ebi.test.js
@@ -9,4 +9,13 @@ describe('ebi command line', () => {
 			done();
 		});
 	});
+
+	it('throws error if package search has search term and regex', done => {
+		const command =
+			'echo "Financial-Times/ebi" | ./bin/ebi.js package --regex regex-term search-term';
+		exec(command, 'utf8', (err, stdout, stderr) => {
+			expect(stderr).toContain('use `search` or `regex`, not both');
+			done();
+		});
+	});
 });

--- a/test/bin/ebi.test.js
+++ b/test/bin/ebi.test.js
@@ -1,0 +1,12 @@
+const { exec } = require('child_process');
+
+describe('ebi command line', () => {
+	it('throws error if contents search has search term and regex', done => {
+		const command =
+			'echo "Financial-Times/ebi" | ./bin/ebi.js contents package.json --regex regex-term search-term';
+		exec(command, 'utf8', (err, stdout, stderr) => {
+			expect(stderr).toContain('use `search` or `regex`, not both');
+			done();
+		});
+	});
+});

--- a/test/commands/package-engines.test.js
+++ b/test/commands/package-engines.test.js
@@ -210,6 +210,81 @@ describe('package:engines command handler', () => {
 			expect.stringContaining('parse error')
 		);
 	});
+
+	test('regex is used for name search', async () => {
+		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
+			type: 'file',
+			content: base64EncodeObj({
+				engines: {
+					node: '~10.15.0'
+				}
+			}),
+			path: 'package.json'
+		});
+		await packageEnginesHandler({
+			regex: 'no.*'
+		});
+
+		expect(console.log).toBeCalledWith(expect.stringContaining(repo));
+	});
+
+	test('regex is used for version search', async () => {
+		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
+			type: 'file',
+			content: base64EncodeObj({
+				engines: {
+					node: '~10.15.0'
+				}
+			}),
+			path: 'package.json'
+		});
+		await packageEnginesHandler({
+			regex: '\\.15\\..*'
+		});
+
+		expect(console.log).toBeCalledWith(expect.stringContaining(repo));
+	});
+
+	test('regex is not matched, logs error', async () => {
+		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
+			type: 'file',
+			content: base64EncodeObj({
+				engines: {
+					node: '~10.15.0'
+				}
+			}),
+			path: 'package.json'
+		});
+		await packageEnginesHandler({
+			regex: 'something$'
+		});
+
+		expect(console.log).not.toBeCalled();
+		expect(console.error).toBeCalledWith(
+			expect.stringContaining('no match')
+		);
+		expect(console.error).toBeCalledWith(expect.stringContaining(repo));
+	});
+
+	test('regex is used if search term also exists', async () => {
+		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
+			type: 'file',
+			content: base64EncodeObj({
+				engines: {
+					node: '~10.15.0'
+				}
+			}),
+			path: 'package.json'
+		});
+		await packageEnginesHandler({
+			regex: 'something-else',
+			search: 'node'
+		});
+
+		expect(console.error).toBeCalledWith(
+			expect.stringContaining('no match')
+		);
+	});
 });
 
 describe.each([

--- a/test/commands/package.test.js
+++ b/test/commands/package.test.js
@@ -86,6 +86,59 @@ describe('package command handler', () => {
 			expect.stringContaining('no match')
 		);
 	});
+
+	test('regex is used for search', async () => {
+		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
+			type: 'file',
+			content: base64EncodeObj({
+				name: 'next-front-page'
+			}),
+			path: 'package.json'
+		});
+		await packageHandler({
+			// NOTE: the extra \'s are not needed on the command line
+			regex: 'front-.*$'
+		});
+
+		expect(console.log).toBeCalledWith(expect.stringContaining(repo));
+	});
+
+	test('regex is not matched, logs error', async () => {
+		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
+			type: 'file',
+			content: base64EncodeObj({
+				name: 'next-front-page'
+			}),
+			path: 'package.json'
+		});
+		await packageHandler({
+			regex: 'something$'
+		});
+
+		expect(console.log).not.toBeCalled();
+		expect(console.error).toBeCalledWith(
+			expect.stringContaining('no regex match')
+		);
+		expect(console.error).toBeCalledWith(expect.stringContaining(repo));
+	});
+
+	test('regex is used if search term also exists', async () => {
+		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
+			type: 'file',
+			content: base64EncodeObj({
+				name: 'next-front-page'
+			}),
+			path: 'package.json'
+		});
+		await packageHandler({
+			regex: 'something-else',
+			search: 'front'
+		});
+
+		expect(console.error).toBeCalledWith(
+			expect.stringContaining('no regex match')
+		);
+	});
 });
 
 describe.each([

--- a/test/lib/object-utils.test.js
+++ b/test/lib/object-utils.test.js
@@ -1,0 +1,113 @@
+const {
+	findMatchedKeyPairs,
+	findMatchedValuePairs,
+	findMatchedKeyValuePairs
+} = require('../../lib/object-utils');
+
+const alwaysTrue = () => true;
+const alwaysFalse = () => false;
+
+describe.each([
+	['undefined', undefined, alwaysTrue, undefined],
+	['empty object', {}, alwaysTrue, {}],
+	[
+		'match key',
+		{ hello: 1, noHello: 2 },
+		key => key === 'hello',
+		{ hello: 1 }
+	],
+	[
+		'no key matched',
+		{ hello: 1, noHello: 2 },
+		key => key === 'something-else',
+		{}
+	]
+])('findMatchedKeyPairs', (description, object, filterFn, expected) => {
+	test(`${description}`, async () => {
+		expect(findMatchedKeyPairs(object, filterFn)).toEqual(expected);
+	});
+});
+
+test('findMatchedKeyPairs returns a new object', () => {
+	const object = { hello: 1 };
+	const result = findMatchedKeyPairs(object, alwaysTrue);
+	expect(result).not.toBe(object);
+});
+
+test('findMatchedKeyPairs does not modify input', () => {
+	const object = { hello: 1 };
+	findMatchedKeyPairs(object, alwaysFalse);
+	expect(object).toEqual({ hello: 1 });
+});
+
+describe.each([
+	['undefined', undefined, alwaysTrue, undefined],
+	['empty object', {}, alwaysTrue, {}],
+	[
+		'match value',
+		{ hello: 1, noHello: 2 },
+		value => value === 1,
+		{ hello: 1 }
+	],
+	[
+		'no value matched',
+		{ hello: 1, noHello: 2 },
+		value => value === 'something-else',
+		{}
+	]
+])('findMatchedValuePairs', (description, object, filterFn, expected) => {
+	test(`${description}`, async () => {
+		expect(findMatchedValuePairs(object, filterFn)).toEqual(expected);
+	});
+});
+
+test('findMatchedValuePairs returns a new object', () => {
+	const object = { hello: 1 };
+	const result = findMatchedValuePairs(object, alwaysTrue);
+	expect(result).not.toBe(object);
+});
+
+test('findMatchedValuePairs does not modify input', () => {
+	const object = { hello: 1 };
+	findMatchedValuePairs(object, alwaysFalse);
+	expect(object).toEqual({ hello: 1 });
+});
+
+describe.each([
+	['undefined', undefined, alwaysTrue, undefined],
+	['empty object', {}, alwaysTrue, {}],
+	[
+		'match key',
+		{ hello: 1, noHello: 2 },
+		value => value === 'hello',
+		{ hello: 1 }
+	],
+	[
+		'match value',
+		{ hello: 1, noHello: 2 },
+		value => value === 1,
+		{ hello: 1 }
+	],
+	[
+		'no value matched',
+		{ hello: 1, noHello: 2 },
+		value => value === 'something-else',
+		{}
+	]
+])('findMatchedKeyValuePairs', (description, object, filterFn, expected) => {
+	test(`${description}`, async () => {
+		expect(findMatchedKeyValuePairs(object, filterFn)).toEqual(expected);
+	});
+});
+
+test('findMatchedValuePairs returns a new object', () => {
+	const object = { hello: 1 };
+	const result = findMatchedKeyValuePairs(object, alwaysTrue);
+	expect(result).not.toBe(object);
+});
+
+test('findMatchedValuePairs does not modify input', () => {
+	const object = { hello: 1 };
+	findMatchedKeyValuePairs(object, alwaysFalse);
+	expect(object).toEqual({ hello: 1 });
+});


### PR DESCRIPTION
Fixes https://github.com/Financial-Times/ebi/issues/1.

To test on the command line using this branch, you can use:

    <repositories> | npx github:financial-times/ebi#features/regex <command> --regex <regex>

Some pre-implementation refactoring: https://github.com/Financial-Times/ebi/commit/e5acaa77e63f29dce84f42b131c59277e8b79183 & https://github.com/Financial-Times/ebi/commit/e480de478e44d7322cf8bd489ba20eec4638ee6e

Implemented regex command for:

* `contents` command: https://github.com/Financial-Times/ebi/commit/3a3eff1a1c74892f1b4e8f512102edde607a9807
    eg,

      echo -e "Financial-Times/ebi\nFinancial-Times/n-heroku-tools" | \
        npx github:financial-times/ebi#features/regex contents package.json --regex "\.15\."

* `package` command: https://github.com/Financial-Times/ebi/commit/8b23976c17419926b79391d5f240e11c8ec599c6
    eg,

      echo -e "Financial-Times/ebi\nFinancial-Times/n-heroku-tools" | \
        npx github:financial-times/ebi#features/regex package --regex "\.15\."

* `package:engines` command: https://github.com/Financial-Times/ebi/commit/b6cadae7e79e30310ad6e4318c52a33f6a843e3c
    eg,

      echo -e "Financial-Times/ebi\nFinancial-Times/n-heroku-tools" | \
        npx github:financial-times/ebi#features/regex package:engines --regex "\.15\."

* Also, when `regex` and `search` are both specified, an error occurs