### PR TITLE
First pass of JSON reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,34 @@ $ echo -e "Financial-Times/ebi" | npx ebi package:engines
 
 For more examples see [Usage Examples](https://github.com/Financial-Times/ebi/wiki/Usage-Examples).
 
+### JSON output
+
+To output as JSON, you can use the `--json` flag eg, `npx ebi package:engines --json`.
+
+The output format of the JSON is
+
+```
+{
+    type,
+    repository,
+    filepath,
+    fileContents,
+    [search],
+    [regex],
+    [error]
+}
+```
+
+| Field          | Values                            | Description                                                   |
+| -------------- | --------------------------------- | ------------------------------------------------------------- |
+| `type`         | `match`, `error`                  | Type of result. Non matches will be under `error`             |
+| `repository`   | `Financial-Times/ebi`             | The full repository path                                      |
+| `filepath`     | `package.json`                    | The filepath searched for                                     |
+| `fileContents` | `{\n  \"name\": \"ebi\",\n ... }` | The file contents serialized as a string                      |
+| `search`       | `name`                            | [optional] The search term                                    |
+| `regex`        | `no.*`                            | [optional] The regex used for search (ie, `--regex`)          |
+| `error`        | `404 ERROR: ...`                  | [optional] The error message if the result is of type `error` |
+
 ## Setting up your GitHub personal access token
 
 This tool requires a [GitHub personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) with all `repo` scopes. This is _very powerful_ as it has access to modify a repository's settings, so it is strongly recommended that you store this token securely.

--- a/lib/create-result.js
+++ b/lib/create-result.js
@@ -1,0 +1,32 @@
+/**
+ * Create result with initial data, then augment with `with*` functions
+ * or custom data
+ */
+const createResult = initData => (data = {}) => {
+	return Object.assign({}, { ...initData }, data);
+};
+
+const withMatch = data => {
+	const matchResult = createResult({ type: 'match' });
+	return matchResult(data);
+};
+
+const withMatchFileContents = fileContents => {
+	return withMatch({
+		fileContents
+	});
+};
+
+const withErrorMessage = message => {
+	const errorResult = createResult({ type: 'error' });
+	return errorResult({
+		error: message
+	});
+};
+
+module.exports = {
+	createResult,
+	withMatch,
+	withMatchFileContents,
+	withErrorMessage
+};

--- a/lib/log-result.js
+++ b/lib/log-result.js
@@ -1,0 +1,25 @@
+/*eslint no-console: ["error", { allow: ["log", "error"] }] */
+const logText = result => {
+	const { type, repository, error } = result;
+	if (type === 'error') {
+		console.error(error);
+	} else {
+		console.log(repository);
+	}
+};
+
+const logTextWithSuffix = suffixFn => result => {
+	const { type, repository, error } = result;
+
+	if (type === 'error') {
+		console.error(error);
+	} else {
+		const suffixStr = suffixFn ? ` ${suffixFn(result)}` : '';
+		console.log(`${repository}${suffixStr}`);
+	}
+};
+
+module.exports = {
+	logText,
+	logTextWithSuffix
+};

--- a/lib/log-result.js
+++ b/lib/log-result.js
@@ -19,7 +19,14 @@ const logTextWithSuffix = suffixFn => result => {
 	}
 };
 
+const logJson = result => {
+	const output = JSON.stringify(result);
+
+	console.log(output);
+};
+
 module.exports = {
 	logText,
-	logTextWithSuffix
+	logTextWithSuffix,
+	logJson
 };

--- a/src/commands/contents.js
+++ b/src/commands/contents.js
@@ -45,7 +45,7 @@ exports.handler = argv => {
 						return console.log(repository);
 					} else {
 						console.error(
-							`INFO: '${filepath}' has no regex match for '${regExp}' in '${repository}'`
+							`INFO: '${filepath}' has no match for '${regExp}' in '${repository}'`
 						);
 					}
 				} else if (noSearch || containsSearchItem) {

--- a/src/commands/contents.js
+++ b/src/commands/contents.js
@@ -1,4 +1,6 @@
 /*eslint no-console: ["error", { allow: ["log", "error"] }] */
+const { flow } = require('lodash');
+
 const getContents = require('../../lib/get-contents');
 const getRepositories = require('../../lib/get-repositories');
 const { withToken, withLimit, withRegex } = require('./shared');
@@ -8,7 +10,8 @@ exports.command = 'contents <filepath> [search]';
 exports.describe = 'Search within a repositories file';
 
 exports.builder = yargs => {
-	return withRegex(withToken(withLimit(yargs)))
+	const baseConfig = flow([withRegex, withToken, withLimit]);
+	return baseConfig(yargs)
 		.positional('filepath', {
 			type: 'string',
 			describe: 'File path to search in GitHub contents API'

--- a/src/commands/contents.js
+++ b/src/commands/contents.js
@@ -2,20 +2,20 @@ const { flow } = require('lodash');
 
 const getContents = require('../../lib/get-contents');
 const getRepositories = require('../../lib/get-repositories');
-const { withToken, withLimit, withRegex } = require('./shared');
+const { withToken, withLimit, withRegex, withJson } = require('./shared');
 const {
 	createResult,
 	withMatchFileContents,
 	withErrorMessage
 } = require('../../lib/create-result');
-const { logText } = require('../../lib/log-result');
+const { logText, logJson } = require('../../lib/log-result');
 
 exports.command = 'contents <filepath> [search]';
 
 exports.describe = 'Search within a repositories file';
 
 exports.builder = yargs => {
-	const baseConfig = flow([withRegex, withToken, withLimit]);
+	const baseConfig = flow([withJson, withRegex, withToken, withLimit]);
 	return baseConfig(yargs)
 		.positional('filepath', {
 			type: 'string',
@@ -29,7 +29,7 @@ exports.builder = yargs => {
 };
 
 exports.handler = argv => {
-	const { filepath, token, search, regex, limit } = argv;
+	const { filepath, token, search, regex, limit, json } = argv;
 
 	const repositories = getRepositories(limit);
 
@@ -77,11 +77,11 @@ exports.handler = argv => {
 
 				return output;
 			})
-			.then(logText)
+			.then(result => (json ? logJson(result) : logText(result)))
 			.catch(error => {
 				const { message } = error;
 				const output = result(withErrorMessage(message));
-				return logText(output);
+				return json ? logJson(output) : logText(output);
 			});
 	});
 

--- a/src/commands/package-engines.js
+++ b/src/commands/package-engines.js
@@ -1,4 +1,6 @@
 /*eslint no-console: ["error", { allow: ["log", "error"] }] */
+const { flow } = require('lodash');
+
 const getContents = require('../../lib/get-contents');
 const getRepositories = require('../../lib/get-repositories');
 const { withToken, withLimit, withRegex } = require('./shared');
@@ -8,7 +10,8 @@ exports.command = 'package:engines [search]';
 exports.desc = 'Search `engines` field inside the `package.json` file';
 
 exports.builder = yargs => {
-	return withRegex(withToken(withLimit(yargs))).positional('search', {
+	const baseConfig = flow([withRegex, withToken, withLimit]);
+	return baseConfig(yargs).positional('search', {
 		type: 'string',
 		describe: 'What to search for. If empty, returns all `engines`'
 	});

--- a/src/commands/package.js
+++ b/src/commands/package.js
@@ -3,20 +3,20 @@ const { flow } = require('lodash');
 
 const getContents = require('../../lib/get-contents');
 const getRepositories = require('../../lib/get-repositories');
-const { withToken, withLimit, withRegex } = require('./shared');
+const { withToken, withLimit, withRegex, withJson } = require('./shared');
 
 const {
 	createResult,
 	withMatchFileContents,
 	withErrorMessage
 } = require('../../lib/create-result');
-const { logText } = require('../../lib/log-result');
+const { logText, logJson } = require('../../lib/log-result');
 
 exports.command = 'package [search]';
 exports.desc = 'Search within the `package.json` file';
 
 exports.builder = yargs => {
-	const baseConfig = flow([withRegex, withToken, withLimit]);
+	const baseConfig = flow([withJson, withRegex, withToken, withLimit]);
 	return baseConfig(yargs).positional('search', {
 		type: 'string',
 		describe:
@@ -25,7 +25,7 @@ exports.builder = yargs => {
 };
 
 exports.handler = function(argv) {
-	const { token, search, limit, regex } = argv;
+	const { token, search, limit, regex, json } = argv;
 	const repositories = getRepositories(limit);
 	const filepath = 'package.json';
 
@@ -71,11 +71,11 @@ exports.handler = function(argv) {
 
 				return output;
 			})
-			.then(logText)
+			.then(result => (json ? logJson(result) : logText(result)))
 			.catch(error => {
 				const { message } = error;
 				const output = result(withErrorMessage(message));
-				return logText(output);
+				return json ? logJson(output) : logText(output);
 			});
 	});
 

--- a/src/commands/package.js
+++ b/src/commands/package.js
@@ -37,7 +37,7 @@ exports.handler = function(argv) {
 						return console.log(repository);
 					} else {
 						console.error(
-							`INFO: '${filepath}' has no regex match for '${regExp}' in '${repository}'`
+							`INFO: '${filepath}' has no match for '${regExp}' in '${repository}'`
 						);
 					}
 				} else if (noSearch || containsSearchItem) {

--- a/src/commands/package.js
+++ b/src/commands/package.js
@@ -1,4 +1,6 @@
 /*eslint no-console: ["error", { allow: ["log", "error"] }] */
+const { flow } = require('lodash');
+
 const getContents = require('../../lib/get-contents');
 const getRepositories = require('../../lib/get-repositories');
 const { withToken, withLimit, withRegex } = require('./shared');
@@ -7,7 +9,8 @@ exports.command = 'package [search]';
 exports.desc = 'Search within the `package.json` file';
 
 exports.builder = yargs => {
-	return withRegex(withToken(withLimit(yargs))).positional('search', {
+	const baseConfig = flow([withRegex, withToken, withLimit]);
+	return baseConfig(yargs).positional('search', {
 		type: 'string',
 		describe:
 			'What to search for. If empty returns whether `package.json` exists or not'

--- a/src/commands/package.js
+++ b/src/commands/package.js
@@ -5,6 +5,13 @@ const getContents = require('../../lib/get-contents');
 const getRepositories = require('../../lib/get-repositories');
 const { withToken, withLimit, withRegex } = require('./shared');
 
+const {
+	createResult,
+	withMatchFileContents,
+	withErrorMessage
+} = require('../../lib/create-result');
+const { logText } = require('../../lib/log-result');
+
 exports.command = 'package [search]';
 exports.desc = 'Search within the `package.json` file';
 
@@ -26,35 +33,51 @@ exports.handler = function(argv) {
 		githubToken: token,
 		filepath
 	});
-	const allRepos = repositories.map(repository =>
-		getPackageJson(repository)
+	const allRepos = repositories.map(repository => {
+		const result = createResult({
+			search,
+			regex,
+			filepath,
+			repository
+		});
+		return getPackageJson(repository)
 			.then(contents => {
 				const noSearch = !search;
 				const containsSearchItem = contents.includes(search);
+				let output;
 
 				if (regex) {
 					const regExp = new RegExp(regex);
 					const hasMatch = contents.match(regExp);
 
 					if (hasMatch) {
-						return console.log(repository);
+						output = result(withMatchFileContents(contents));
 					} else {
-						console.error(
-							`INFO: '${filepath}' has no match for '${regExp}' in '${repository}'`
+						output = result(
+							withErrorMessage(
+								`INFO: '${filepath}' has no match for '${regExp}' in '${repository}'`
+							)
 						);
 					}
 				} else if (noSearch || containsSearchItem) {
-					return console.log(repository);
+					output = result(withMatchFileContents(contents));
 				} else {
-					return console.error(
-						`INFO: '${filepath}' has no match for '${search}' in '${repository}'`
+					output = result(
+						withErrorMessage(
+							`INFO: '${filepath}' has no match for '${search}' in '${repository}'`
+						)
 					);
 				}
+
+				return output;
 			})
+			.then(logText)
 			.catch(error => {
-				console.error(error.message);
-			})
-	);
+				const { message } = error;
+				const output = result(withErrorMessage(message));
+				return logText(output);
+			});
+	});
 
 	return Promise.all(allRepos);
 };

--- a/src/commands/shared.js
+++ b/src/commands/shared.js
@@ -35,4 +35,12 @@ const withRegex = yargs => {
 		});
 };
 
-module.exports = { withLimit, withToken, withRegex };
+const withJson = yargs => {
+	return yargs.option('json', {
+		type: 'boolean',
+		default: false,
+		describe: 'Output JSON (including errors)'
+	});
+};
+
+module.exports = { withLimit, withToken, withRegex, withJson };

--- a/test/commands/contents.test.js
+++ b/test/commands/contents.test.js
@@ -129,7 +129,7 @@ describe('contents command handler', () => {
 
 		expect(console.log).not.toBeCalled();
 		expect(console.error).toBeCalledWith(
-			expect.stringContaining('no regex match')
+			expect.stringContaining('no match')
 		);
 		expect(console.error).toBeCalledWith(expect.stringContaining(repo));
 	});
@@ -147,7 +147,7 @@ describe('contents command handler', () => {
 		});
 
 		expect(console.error).toBeCalledWith(
-			expect.stringContaining('no regex match')
+			expect.stringContaining('no match')
 		);
 	});
 });

--- a/test/commands/contents.test.js
+++ b/test/commands/contents.test.js
@@ -152,6 +152,85 @@ describe('contents command handler', () => {
 	});
 });
 
+describe('json output', () => {
+	test('shows json', async () => {
+		nockScope.get(`/${repo}/contents/Procfile`).reply(200, {
+			type: 'file',
+			content: base64Encode('web: node 1234.js'),
+			path: 'Procfile'
+		});
+		await contentsHandler({
+			json: true,
+			filepath: 'Procfile'
+		});
+
+		const log = JSON.parse(console.log.mock.calls[0][0]);
+		expect(log).toEqual({
+			type: 'match',
+			filepath: 'Procfile',
+			repository: repo,
+			fileContents: 'web: node 1234.js'
+		});
+	});
+
+	test('shows json with search', async () => {
+		nockScope.get(`/${repo}/contents/Procfile`).reply(200, {
+			type: 'file',
+			content: base64Encode('web: node 1234.js'),
+			path: 'Procfile'
+		});
+		await contentsHandler({
+			json: true,
+			filepath: 'Procfile',
+			search: 'node'
+		});
+
+		const log = JSON.parse(console.log.mock.calls[0][0]);
+		expect(log).toEqual({
+			type: 'match',
+			filepath: 'Procfile',
+			search: 'node',
+			repository: repo,
+			fileContents: 'web: node 1234.js'
+		});
+	});
+
+	test('shows json with regex', async () => {
+		nockScope.get(`/${repo}/contents/Procfile`).reply(200, {
+			type: 'file',
+			content: base64Encode('web: node 1234.js'),
+			path: 'Procfile'
+		});
+		await contentsHandler({
+			json: true,
+			filepath: 'Procfile',
+			regex: 'node'
+		});
+
+		const log = JSON.parse(console.log.mock.calls[0][0]);
+		expect(log).toEqual({
+			type: 'match',
+			filepath: 'Procfile',
+			regex: 'node',
+			repository: repo,
+			fileContents: 'web: node 1234.js'
+		});
+	});
+
+	test('shows json error', async () => {
+		nockScope.get(`/${repo}/contents/Procfile`).reply(404);
+		await contentsHandler({ filepath: 'Procfile', json: true });
+
+		const log = JSON.parse(console.log.mock.calls[0][0]);
+		expect(log).toEqual({
+			type: 'error',
+			filepath: 'Procfile',
+			repository: repo,
+			error: expect.stringContaining('not found')
+		});
+	});
+});
+
 describe.each([
 	[
 		[

--- a/test/commands/package-engines.test.js
+++ b/test/commands/package-engines.test.js
@@ -287,6 +287,86 @@ describe('package:engines command handler', () => {
 	});
 });
 
+describe('json output', () => {
+	let packageJson;
+	beforeEach(() => {
+		packageJson = {
+			engines: {
+				node: '~10.15.0'
+			}
+		};
+	});
+
+	test('shows json', async () => {
+		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
+			type: 'file',
+			content: base64EncodeObj(packageJson),
+			path: 'package.json'
+		});
+		await packageEnginesHandler({ json: true });
+
+		const log = JSON.parse(console.log.mock.calls[0][0]);
+		expect(log).toEqual({
+			type: 'match',
+			filepath: 'package.json',
+			engines: packageJson.engines,
+			fileContents: JSON.stringify(packageJson),
+			repository: repo
+		});
+	});
+
+	test('shows json with search', async () => {
+		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
+			type: 'file',
+			content: base64EncodeObj(packageJson),
+			path: 'package.json'
+		});
+		await packageEnginesHandler({ json: true, search: 'node' });
+
+		const log = JSON.parse(console.log.mock.calls[0][0]);
+		expect(log).toEqual({
+			type: 'match',
+			filepath: 'package.json',
+			search: 'node',
+			engines: packageJson.engines,
+			fileContents: JSON.stringify(packageJson),
+			repository: repo
+		});
+	});
+
+	test('shows json with regex', async () => {
+		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
+			type: 'file',
+			content: base64EncodeObj(packageJson),
+			path: 'package.json'
+		});
+		await packageEnginesHandler({ json: true, regex: 'no.*' });
+
+		const log = JSON.parse(console.log.mock.calls[0][0]);
+		expect(log).toEqual({
+			type: 'match',
+			filepath: 'package.json',
+			regex: 'no.*',
+			engines: packageJson.engines,
+			fileContents: JSON.stringify(packageJson),
+			repository: repo
+		});
+	});
+
+	test('shows json with error', async () => {
+		nockScope.get(`/${repo}/contents/package.json`).reply(404);
+		await packageEnginesHandler({ json: true });
+
+		const log = JSON.parse(console.log.mock.calls[0][0]);
+		expect(log).toEqual({
+			type: 'error',
+			filepath: 'package.json',
+			repository: repo,
+			error: expect.stringContaining('not found')
+		});
+	});
+});
+
 describe.each([
 	[
 		[

--- a/test/commands/package.test.js
+++ b/test/commands/package.test.js
@@ -141,6 +141,82 @@ describe('package command handler', () => {
 	});
 });
 
+describe('json output', () => {
+	let packageJson;
+	beforeEach(() => {
+		packageJson = {
+			name: 'next-front-page'
+		};
+	});
+
+	test('shows json', async () => {
+		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
+			type: 'file',
+			content: base64EncodeObj(packageJson),
+			path: 'package.json'
+		});
+		await packageHandler({ json: true });
+
+		const log = JSON.parse(console.log.mock.calls[0][0]);
+		expect(log).toEqual({
+			type: 'match',
+			filepath: 'package.json',
+			repository: repo,
+			fileContents: JSON.stringify(packageJson)
+		});
+	});
+
+	test('shows json with search', async () => {
+		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
+			type: 'file',
+			content: base64EncodeObj(packageJson),
+			path: 'package.json'
+		});
+		await packageHandler({ search: 'name', json: true });
+
+		const log = JSON.parse(console.log.mock.calls[0][0]);
+		expect(log).toEqual({
+			type: 'match',
+			filepath: 'package.json',
+			search: 'name',
+			repository: repo,
+			fileContents: JSON.stringify(packageJson)
+		});
+	});
+
+	test('shows json with regex', async () => {
+		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
+			type: 'file',
+			content: base64EncodeObj(packageJson),
+			path: 'package.json'
+		});
+		await packageHandler({ regex: 'front-.*', json: true });
+
+		const log = JSON.parse(console.log.mock.calls[0][0]);
+		expect(log).toEqual({
+			type: 'match',
+			filepath: 'package.json',
+			regex: 'front-.*',
+			repository: repo,
+			fileContents: JSON.stringify(packageJson)
+		});
+	});
+
+	test('shows json error', async () => {
+		nockScope.get(`/${repo}/contents/package.json`).reply(404);
+		await packageHandler({ search: 'something', json: true });
+
+		const log = JSON.parse(console.log.mock.calls[0][0]);
+		expect(log).toEqual({
+			type: 'error',
+			filepath: 'package.json',
+			repository: repo,
+			search: 'something',
+			error: expect.stringContaining('not found')
+		});
+	});
+});
+
 describe.each([
 	[
 		[

--- a/test/commands/package.test.js
+++ b/test/commands/package.test.js
@@ -117,7 +117,7 @@ describe('package command handler', () => {
 
 		expect(console.log).not.toBeCalled();
 		expect(console.error).toBeCalledWith(
-			expect.stringContaining('no regex match')
+			expect.stringContaining('no match')
 		);
 		expect(console.error).toBeCalledWith(expect.stringContaining(repo));
 	});
@@ -136,7 +136,7 @@ describe('package command handler', () => {
 		});
 
 		expect(console.error).toBeCalledWith(
-			expect.stringContaining('no regex match')
+			expect.stringContaining('no match')
 		);
 	});
 });


### PR DESCRIPTION
First pass of implementing JSON reporting for #26.

Main ideas behind this PR:

* Using the `--json` flag to output JSON for all commands
* Being very verbose in the output, as it's intended more for post processing (than humans), and providing all the data we get from GitHub allows for developers to find creative ways to find the nuggets of information they want.

  eg, Post `ebi` filtering using `jq` to get all `package.json` files, then getting the `name` field from each `package.json`

      echo -e "Financial-Times/ebi\nFinancial-Times/n-membership-sdk" | \
        npx github:financial-times/ebi#features/reporting contents package.json --json | \
        jq .fileContents --raw-output | \
        jq .name

Most of the feature is implemented in: 2878f31
Pre-feature refactoring: 277395a, d66b295, 23114f6