### PR TITLE
Allow more GitHub repo url formats

### DIFF
--- a/lib/get-repositories.js
+++ b/lib/get-repositories.js
@@ -1,26 +1,29 @@
 const fs = require('fs');
+const { GITHUB_REPO_REGEX, extractOwnerAndRepo } = require('./github-helpers');
 
 const getRepositories = limit => {
-	const repoFormat = /^[^\/]+\/[^\/]+$/;
 	const input = fs.readFileSync('/dev/stdin') || '';
 	const inputRepositories = input.toString().split('\n');
 
 	const errors = inputRepositories
-		.map((repository, index) => {
-			const hasRepository = !!repository;
-			const formatError = !repository.match(repoFormat);
+		.map((githubRepoString, index) => {
+			const hasRepository = !!githubRepoString;
+			const formatError = !githubRepoString.match(GITHUB_REPO_REGEX);
 			const line = index + 1;
 			if (hasRepository && formatError) {
 				return {
-					repository,
+					repository: githubRepoString,
 					line
 				};
 			}
 		})
 		.filter(error => !!error);
-	const filteredRepositories = inputRepositories.filter(
-		repo => !!repo.match(repoFormat)
-	);
+	const filteredRepositories = inputRepositories
+		.filter(githubRepoString => !!githubRepoString.match(GITHUB_REPO_REGEX))
+		.map(githubRepoString => {
+			const { owner, repo } = extractOwnerAndRepo(githubRepoString);
+			return `${owner}/${repo}`;
+		});
 
 	const repositoriesWithLimit = limit
 		? filteredRepositories.slice(0, limit)

--- a/lib/github-helpers.js
+++ b/lib/github-helpers.js
@@ -1,0 +1,45 @@
+const GITHUB_REPO_REGEX = /^(?:\S*github\.com(?:\/|:))?([\w-]+)\/([\w-]+)/;
+
+/**
+ * Array of repo string patterns supported by `extractOwnerAndRepo`.
+ *
+ * @type {Array<string>}
+ */
+const SUPPORTED_REPO_STRING_PATTERNS = [
+	'github-organization/github-repo-name',
+	'github.com/github-organization/github-repo-name',
+	'subdomain.github.com/github-organization/github-repo-name',
+	'https://github.com/github-organization/github-repo-name',
+	'https://github.com/github-organization/github-repo-name/blob/master',
+	'https://github.com/github-organization/github-repo-name.git',
+	'git+https://github.com/github-organization/github-repo-name.git',
+	'git@github.com:github-organization/github-repo-name.git'
+];
+
+/**
+ * Parses owner and repo from a supported list of string patterns defined by
+ * `SUPPORTED_REPO_STRING_PATTERNS`.
+ *
+ * @param {string} githubRepoString
+ * @returns {object} - Properties: owner, repo
+ */
+function extractOwnerAndRepo(githubRepoString) {
+	const matches = GITHUB_REPO_REGEX.exec(githubRepoString);
+
+	if (matches === null) {
+		throw new Error(
+			`ERROR: Could not extract owner and repo from provided string. The string must match one of the following patterns:\n\n- ${SUPPORTED_REPO_STRING_PATTERNS.join(
+				'\n- '
+			)}`
+		);
+	}
+	const [, owner, repo] = matches;
+
+	return { owner, repo };
+}
+
+module.exports = {
+	GITHUB_REPO_REGEX,
+	SUPPORTED_REPO_STRING_PATTERNS,
+	extractOwnerAndRepo
+};

--- a/test/lib/get-repositories.test.js
+++ b/test/lib/get-repositories.test.js
@@ -32,6 +32,15 @@ describe('getRepositories', () => {
 		expect(repository).toEqual('Financial-Times/something');
 	});
 
+	test('works for full github repository links', () => {
+		createStandardInput('https://github.com/Financial-Times/something.git');
+
+		const {
+			repositories: [repository]
+		} = getRepositories();
+		expect(repository).toEqual('Financial-Times/something');
+	});
+
 	test('splits by newline', () => {
 		createStandardInput(
 			'Financial-Times/something\nFinancial-Times/something-else'
@@ -65,7 +74,6 @@ describe.each`
 	${'/'}                                          | ${[{ repository: '/', line: 1 }]}
 	${'something/'}                                 | ${[{ repository: 'something/', line: 1 }]}
 	${'/something'}                                 | ${[{ repository: '/something', line: 1 }]}
-	${'something/something/'}                       | ${[{ repository: 'something/something/', line: 1 }]}
 	${'/something/something'}                       | ${[{ repository: '/something/something', line: 1 }]}
 	${'owner/good1\nbad-one\nowner/good2\nbad-two'} | ${[{ repository: 'bad-one', line: 2 }, { repository: 'bad-two', line: 4 }]}
 `(`getRepositories errors for '$input'`, ({ input, expectedErrors }) => {

--- a/test/lib/github-helpers.test.js
+++ b/test/lib/github-helpers.test.js
@@ -1,0 +1,46 @@
+const {
+	extractOwnerAndRepo,
+	SUPPORTED_REPO_STRING_PATTERNS
+} = require('../../lib/github-helpers');
+
+const expectedOwner = 'github-organization';
+const expectedRepo = 'github-repo-name';
+
+const supportedRepoStrings = SUPPORTED_REPO_STRING_PATTERNS;
+
+const unsupportedRepoStrings = [
+	`https://github.com/${expectedOwner}`,
+	`this is junk subdomain.github.com/${expectedOwner}/${expectedRepo}`,
+	`this is absolute/rubbish that we will not support`
+];
+
+afterEach(() => {
+	jest.clearAllMocks();
+});
+
+supportedRepoStrings.forEach(githubRepoString => {
+	test(
+		'calling `extractOwnerAndRepo` with `' +
+			githubRepoString +
+			'` returns `owner` and `repo`',
+		() => {
+			const { owner, repo } = extractOwnerAndRepo(githubRepoString);
+
+			expect(owner).toEqual(expectedOwner);
+			expect(repo).toEqual(expectedRepo);
+		}
+	);
+});
+
+unsupportedRepoStrings.forEach(githubRepoString => {
+	test(
+		'calling `extractOwnerAndRepo` with `' +
+			githubRepoString +
+			'` will throw an error',
+		() => {
+			expect(() => {
+				extractOwnerAndRepo(githubRepoString);
+			}).toThrowError('Could not extract owner and repo');
+		}
+	);
+});


### PR DESCRIPTION
Merge `extractOwnerAndRepo` function from manage-github-apps to allow
for more GitHub url formats to be piped in. Also allows for `/` after
GitHub owner + repo names.

See: https://github.com/Financial-Times/manage-github-apps/blob/d114798cf1f98f5e7796a1b3157c8d57620f9a44/src/lib/github.js#L40

Fixes https://github.com/Financial-Times/ebi/issues/72

To try it out with:

    echo -e "git+https://github.com/Financial-Times/ebi.git" | npx financial-times/ebi#features/add-support-for-repo-formats package:engines

Previously it would error:

```
$ echo -e "git+https://github.com/Financial-Times/ebi.git" | npx financial-times/ebi package:engines
npx: installed 100 in 4.689s
ERROR: invalid repository 'git+https://github.com/Financial-Times/ebi.git' on line 1
```