### PR TITLE
Clean up CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,4 @@
 # See https://help.github.com/articles/about-codeowners/ for more information
 # about this file.
 
-*      jennifer.johnson@ft.com tak.tran@ft.com
+*      jennifer.johnson@ft.com jennifer.shepherd@ft.com tak.tran@ft.com

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,4 @@
 # See https://help.github.com/articles/about-codeowners/ for more information
 # about this file.
 
-*       @jkerr321 @taktran
+*      jennifer.johnson@ft.com tak.tran@ft.com

--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
 			"email": "jennifer.johnson@ft.com"
 		},
 		{
+			"name": "Jennifer Shepherd",
+			"email": "jennifer.shepherd@ft.com"
+		},
+		{
 			"name": "Tak Tran",
 			"email": "tak.tran@ft.com"
 		}

--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
 	"contributors": [
 		{
 			"name": "Jennifer Johnson",
-			"email": "jkerr321@gmail.com"
+			"email": "jennifer.johnson@ft.com"
 		},
 		{
 			"name": "Tak Tran",
-			"email": "contact@tutaktran.com"
+			"email": "tak.tran@ft.com"
 		}
 	],
 	"license": "MIT",


### PR DESCRIPTION
* Use ft emails instead of GitHub usernames. Inspired by: https://github.com/Financial-Times/next-transformations/tree/master/transformations/2019-03-codeowners
* Add Jen no.2 to contributors/owners 🎉 