### PR TITLE
 Support input where there is both standard input and arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,44 @@ This tool requires a [GitHub personal access token](https://help.github.com/arti
         # or,
         ./bin/ebi.js <command>
 
+### Testing
+
+To run linting and tests
+
+    npm test
+
+To just run linting
+
+    npm run lint
+
+To fix linting issues
+
+    npm run lint-fix
+
+To just run unit tests
+
+    npm run unit-test
+
+To watch files and run unit tests
+
+    npm run unit-test:watch
+
+To watch individual files and run unit tests
+
+    npm run unit-test:watch -- [file...]
+    # eg,
+    npm run unit-test:watch -- test/lib/get-repositories.test.js
+
 ### Code formatting with Prettier
 
 This repo uses [prettier](https://prettier.io/) for code formatting. To make the most of this when working locally:
 
 -   Install the [`prettier-vscode`](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) extension in the extension side bar
 -   Update your settings to format files on save. This will check your file meets the prettier guidelines and will fix it each time you save. You can update the setting at `Code` --> `Preferences` --> `Settings` --> update `"editor.formatOnSave": true`
+
+To make sure no `eslint` rules conflict with the prettier config, we have [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier). This can be run with:
+
+    npm run eslint-check
 
 ### Publishing a release
 

--- a/lib/get-repositories.js
+++ b/lib/get-repositories.js
@@ -1,22 +1,13 @@
 const { GITHUB_REPO_REGEX, extractOwnerAndRepo } = require('./github-helpers');
 const readStardardInputLines = require('./read-standard-input-lines');
 
-const getRepositories = async ({ limit, repoList } = {}) => {
+const getRepositories = async ({ limit, repoList = [] } = {}) => {
 	let inputRepositories;
 
 	const hasStdIn = !process.stdin.isTTY;
+	const stdinRepositories = hasStdIn ? await readStardardInputLines() : [];
 
-	if (Array.isArray(repoList) && repoList.length > 0 && hasStdIn) {
-		throw new Error(
-			'choose either to pipe through a repo list OR pass it as args'
-		);
-	}
-
-	if (hasStdIn) {
-		inputRepositories = await readStardardInputLines();
-	} else {
-		inputRepositories = repoList;
-	}
+	inputRepositories = repoList.concat(stdinRepositories);
 
 	const errors = inputRepositories
 		.map((githubRepoString, index) => {

--- a/lib/read-standard-input-lines.js
+++ b/lib/read-standard-input-lines.js
@@ -7,6 +7,12 @@ function readStardardInputLines() {
 
 	return new Promise(resolve => {
 		const lines = [];
+
+		// readlineInterface is undefined when there is no standard input
+		if (!readlineInterface) {
+			return resolve(lines);
+		}
+
 		readlineInterface
 			.on('line', line => {
 				if (!line) {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
 		"lint-fix": "eslint --fix *.js src/ lib/ test/",
 		"eslint-check": "eslint --print-config . | eslint-config-prettier-check",
 		"test": "npm run lint && npm run unit-test",
-		"unit-test": "jest"
+		"unit-test": "jest",
+		"unit-test:watch": "jest --watch"
 	},
 	"repository": {
 		"type": "git",

--- a/test/helpers/setup-readline.js
+++ b/test/helpers/setup-readline.js
@@ -4,24 +4,29 @@ jest.mock('readline');
 
 /**
  * Mock implementation of readline
+ *
+ * @param {function} createInterface - Mock implementation of `readline.createInterface`. Uses a default implementation if not specified
  */
-const setupReadline = () => {
+const setupReadline = ({ createInterface } = {}) => {
 	let lineFn = () => {};
 	let closeFn = () => {};
-	const readlineInterface = {
-		// Keep a reference of the line and close function, so it can
-		// be run later
-		on: (event, fn) => {
-			if (event === 'line') {
-				lineFn = fn;
-			} else if (event === 'close') {
-				closeFn = fn;
-			}
-			return readlineInterface;
-		}
-	};
 
-	readline.createInterface.mockImplementation(() => readlineInterface);
+	const mockReadlineInterface = !!createInterface
+		? createInterface()
+		: {
+				// Keep a reference of the line and close function, so it can
+				// be run later
+				on: (event, fn) => {
+					if (event === 'line') {
+						lineFn = fn;
+					} else if (event === 'close') {
+						closeFn = fn;
+					}
+					return mockReadlineInterface;
+				}
+		  };
+
+	readline.createInterface.mockImplementation(() => mockReadlineInterface);
 	const initialIsTTY = process.stdin.isTTY;
 	// Allow standard input to be detected
 	process.stdin.isTTY = false;

--- a/test/lib/get-repositories.test.js
+++ b/test/lib/get-repositories.test.js
@@ -1,8 +1,19 @@
 const setupReadline = require('../helpers/setup-readline');
 const getRepositories = require('../../lib/get-repositories');
 
-const getRepositoriesWithCleanup = async ({ input, args }) => {
-	const { readString, teardown } = setupReadline();
+/**
+ * Get repositories with clean up of readline
+ *
+ * @param {string} input - standard input string
+ * @param {any} args - `getRepositories` arguments
+ * @param {any} setupReadlineArgs - `setupReadline` arguments
+ */
+const getRepositoriesWithCleanup = async ({
+	input,
+	args,
+	setupReadlineArgs
+}) => {
+	const { readString, teardown } = setupReadline(setupReadlineArgs);
 
 	const getRepos = getRepositories(args);
 	readString(input);
@@ -117,15 +128,15 @@ describe('getRepositories', () => {
 		expect(repository).toEqual('Financial-Times/something');
 	});
 
-	test('providing stdin and repoList arg produces error', async () => {
-		await expect(
-			getRepositoriesWithCleanup({
-				input: 'Financial-Times/something',
-				args: { repoList: ['Financial-Times/something'] }
-			})
-		).rejects.toThrowError(
-			'choose either to pipe through a repo list OR pass it as args'
-		);
+	test('providing stdin and repoList arg processes args then stdin', async () => {
+		const { repositories } = await getRepositoriesWithCleanup({
+			input: 'Financial-Times/something-else',
+			args: { repoList: ['Financial-Times/something'] }
+		});
+		expect(repositories).toEqual([
+			'Financial-Times/something',
+			'Financial-Times/something-else'
+		]);
 	});
 });
 

--- a/test/lib/read-standard-input-lines.test.js
+++ b/test/lib/read-standard-input-lines.test.js
@@ -1,7 +1,7 @@
 const setupReadline = require('../helpers/setup-readline');
 const readStardardInputLines = require('../../lib/read-standard-input-lines');
 
-const setupReadStdin = async input => {
+const setupReadStdin = async ({ input } = {}) => {
 	const { readString, teardown } = setupReadline();
 	const read = readStardardInputLines();
 	readString(input);
@@ -18,22 +18,24 @@ describe('readStardardInputLines', () => {
 	});
 
 	test('outputs empty array with empty string', async () => {
-		const lines = await setupReadStdin('');
+		const lines = await setupReadStdin({ input: '' });
 		expect(lines).toEqual([]);
 	});
 
 	test('outputs one line', async () => {
-		const lines = await setupReadStdin('something');
+		const lines = await setupReadStdin({ input: 'something' });
 		expect(lines).toEqual(['something']);
 	});
 
 	test('outputs multiple lines', async () => {
-		const lines = await setupReadStdin('something\nsomething2');
+		const lines = await setupReadStdin({ input: 'something\nsomething2' });
 		expect(lines).toEqual(['something', 'something2']);
 	});
 
 	test('outputs ignores empty lines', async () => {
-		const lines = await setupReadStdin('something\n\nsomething2');
+		const lines = await setupReadStdin({
+			input: 'something\n\nsomething2'
+		});
 		expect(lines).toEqual(['something', 'something2']);
 	});
 });

--- a/test/lib/read-standard-input-lines.test.js
+++ b/test/lib/read-standard-input-lines.test.js
@@ -1,8 +1,8 @@
 const setupReadline = require('../helpers/setup-readline');
 const readStardardInputLines = require('../../lib/read-standard-input-lines');
 
-const setupReadStdin = async ({ input } = {}) => {
-	const { readString, teardown } = setupReadline();
+const setupReadStdin = async ({ input, createInterface } = {}) => {
+	const { readString, teardown } = setupReadline({ createInterface });
 	const read = readStardardInputLines();
 	readString(input);
 	const lines = await read;
@@ -14,6 +14,12 @@ const setupReadStdin = async ({ input } = {}) => {
 describe('readStardardInputLines', () => {
 	test('outputs empty array with no input', async () => {
 		const lines = await setupReadStdin();
+		expect(lines).toEqual([]);
+	});
+
+	test('outputs empty array with no readline interface (ie, no standard input)', async () => {
+		// Return nothing for createInterface to simulate no standard input
+		const lines = await setupReadStdin({ createInterface: () => {} });
 		expect(lines).toEqual([]);
 	});
 


### PR DESCRIPTION
Rather than error when there are input repos from both standard input and arguments, just allow it and process both. Especially good for usage with `xargs`. Also made the arbitrary call to process standard input after arguments, to mimic `xargs` usage.

Main fix is in 1d14851af0c8eeb2582e78f18623791786c12fe4, with other commits being clean up and refactoring steps. e1b0a6845d15bcb5d09fffc2222288971a3cb60e also fixes an issue where we try to use `readline` when there is no standard input.

Fixes #87

## To test this

### stdin

    echo 'Financial-Times/next-static' | ./bin/ebi.js package ''

Returns stdin result

    Financial-Times/next-static

### args

    ./bin/ebi.js package '' Financial-Times/next-static
    
Returns arg result

    Financial-Times/next-static

### stdin + args

    echo 'Financial-Times/next-static' | ./bin/ebi.js package '' 'Financial-Times/next-search-page'

Returns arg result, then stdin result (like `stdin + xargs + args` below)

    Financial-Times/next-search-page
    Financial-Times/next-static

### stdin + xargs

    echo 'Financial-Times/next-static' | xargs ./bin/ebi.js package ''

Returns stdin result

    Financial-Times/next-static

### stdin + xargs + args

    echo 'Financial-Times/next-static' | xargs ./bin/ebi.js package '' 'Financial-Times/next-search-page'

Returns arg result, then stdin result

    Financial-Times/next-search-page
    Financial-Times/next-static
