### PR TITLE
Install update-notifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,18 +98,15 @@ This tool requires a [GitHub personal access token](https://help.github.com/arti
 
 1.  Install [nvm](https://github.com/creationix/nvm) and use the correct node version
 
-        nvm use
+        `nvm use`
 
 1.  Install dependencies
 
-        npm install
+        `npm install`
 
 1.  Run with:
 
-        npx --package . ebi <command>
-
-        # or,
-        ./bin/ebi.js <command>
+        `./bin/ebi.js <command>`
 
 ### Code formatting with Prettier
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Ebi (えび) is [Japanese for prawn/shrimp](https://translate.google.com/#view=h
 ## Global installation (recommmended)
 
 `npm install --global @financial-times/ebi`
+
 When you run the tool, it will automatically notify you if there is a newer version of it available for you to update to.
 
 [You can disable notifications](https://www.npmjs.com/package/update-notifier#user-settings) if you'd prefer not to be notified about updates.
@@ -18,6 +19,7 @@ When you run the tool, it will automatically notify you if there is a newer vers
 ## No installation
 
 `npx @financial-times/ebi`
+
 The npx command lets you use this tool without installing it. However, each time you use npx it downloads the whole package from the npm registry, which takes a while. That's why global installation is reccommended.
 
 > Note: If this tool is globally installed, npx @financial-times/ebi will use that globally installed version rather than downloading.
@@ -98,15 +100,15 @@ This tool requires a [GitHub personal access token](https://help.github.com/arti
 
 1.  Install [nvm](https://github.com/creationix/nvm) and use the correct node version
 
-        `nvm use`
+        nvm use
 
 1.  Install dependencies
 
-        `npm install`
+        npm install
 
 1.  Run with:
 
-        `./bin/ebi.js <command>`
+        ./bin/ebi.js <command>
 
 ### Code formatting with Prettier
 

--- a/README.md
+++ b/README.md
@@ -8,42 +8,56 @@ A command line tool that searches files within GitHub repositories.
 
 Ebi (えび) is [Japanese for prawn/shrimp](https://translate.google.com/#view=home&op=translate&sl=en&tl=ja&text=Prawn), and intends to be a small little tool to crawl through your sea of code on GitHub, finding you nuggets of information.
 
+## Global installation (recommmended)
+
+`npm install --global @financial-times/ebi`
+When you run the tool, it will automatically notify you if there is a newer version of it available for you to update to.
+
+[You can disable notifications](https://www.npmjs.com/package/update-notifier#user-settings) if you'd prefer not to be notified about updates.
+
+## No installation
+
+`npx @financial-times/ebi`
+The npx command lets you use this tool without installing it. However, each time you use npx it downloads the whole package from the npm registry, which takes a while. That's why global installation is reccommended.
+
+> Note: If this tool is globally installed, npx @financial-times/ebi will use that globally installed version rather than downloading.
+
 ## Usage
 
 1.  [Set up a GitHub personal access token](#setting-up-your-github-personal-access-token) (with all `repo` scopes) assigned to the `GITHUB_PERSONAL_ACCESS_TOKEN` environment variable
 
 2.  Pass in the list of space-separated repositories as arguments:
 
-        npx ebi <command> Financial-Times/ebi Financial-Times/tako
+        ebi <command> Financial-Times/ebi Financial-Times/tako
 
 ### Examples
 
 Show help
 
-    npx ebi --help
+    ebi --help
 
 Input the repositories to the ebi command either via `stdin` or `args`.
 Determine whether a repo has a `Procfile`
 
 ```
-$ echo -e "Financial-Times/ebi" | npx ebi contents Procfile
+$ echo -e "Financial-Times/ebi" | ebi contents Procfile
 ```
 
 ```
-$ npx ebi contents Procfile Financial-Times/ebi
+$ ebi contents Procfile Financial-Times/ebi
 ```
 
 Find all the `node` engines and their versions in `package.json`
 
 ```
-$ cat repositories.txt | npx ebi package:engines
+$ cat repositories.txt | ebi package:engines
 ```
 
 For more examples see [Usage Examples](https://github.com/Financial-Times/ebi/wiki/Usage-Examples).
 
 ### JSON output
 
-To output as JSON, you can use the `--json` flag eg, `npx ebi package:engines --json`.
+To output as JSON, you can use the `--json` flag eg, `ebi package:engines --json`.
 
 The output format of the JSON is
 
@@ -59,15 +73,15 @@ The output format of the JSON is
 }
 ```
 
-| Field          | Values                            | Description                                                   |
-| -------------- | --------------------------------- | ------------------------------------------------------------- |
-| `type`         | `match`, `error`                  | Type of result. Non matches will be under `error`             |
-| `repository`   | `Financial-Times/ebi`             | The full repository path                                      |
-| `filepath`     | `package.json`                    | The filepath searched for                                     |
-| `fileContents` | `{\n  \"name\": \"ebi\",\n ... }` | The file contents serialized as a string                      |
-| `search`       | `name`                            | [optional] The search term                                    |
-| `regex`        | `no.*`                            | [optional] The regex used for search (ie, `--regex`)          |
-| `error`        | `404 ERROR: ...`                  | [optional] The error message if the result is of type `error` |
+| Field          | Values                           | Description                                                   |
+| -------------- | -------------------------------- | ------------------------------------------------------------- |
+| `type`         | `match`, `error`                 | Type of result. Non matches will be under `error`             |
+| `repository`   | `Financial-Times/ebi`            | The full repository path                                      |
+| `filepath`     | `package.json`                   | The filepath searched for                                     |
+| `fileContents` | `{\n \"name\": \"ebi\",\n ... }` | The file contents serialized as a string                      |
+| `search`       | `name`                           | [optional] The search term                                    |
+| `regex`        | `no.*`                           | [optional] The regex used for search (ie, `--regex`)          |
+| `error`        | `404 ERROR: ...`                 | [optional] The error message if the result is of type `error` |
 
 ## Setting up your GitHub personal access token
 

--- a/bin/ebi.js
+++ b/bin/ebi.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+require('./helpers/update-notifier');
+
 const { withEpilogue } = require('../src/commands/shared');
 
 const yargs = require('yargs');

--- a/bin/helpers/update-notifier.js
+++ b/bin/helpers/update-notifier.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+const updateNotifier = require('update-notifier');
+/**
+ * Display a notification if a newer version of this package is available to install.
+ *
+ * This check for updates to the `@financial-times/ebi` package
+ * happens asynchronously in a detached child process that runs
+ * independently from the parent CLI process. This ensures that
+ * the check for updates doesn't interfere with the running of the
+ * CLI itself. If an update is available, the user won't be notified
+ * about it until the next time that they run the CLI.
+ *
+ * Note: `update-notifier` checks for updates once a day by default.
+ *
+ * @see https://www.npmjs.com/package/update-notifier
+ */
+const packageJson = require('../../package.json');
+
+updateNotifier({ pkg: packageJson }).notify();

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 		"@octokit/rest": "^16.15.0",
 		"lodash": "^4.17.11",
 		"nock": "^10.0.6",
+		"update-notifier": "^2.5.0",
 		"yargs": "^13.1.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
So that developers can be informed when there is a new ebi version available through npm, we want to install update-notifier.

Fixes #89 .

More information on this package can be found [here](https://www.npmjs.com/package/update-notifier).

N.B. from the docs when testing: 
```The first time the user runs your app, it will check for an update, and even if an update is available, it will wait the specified updateCheckInterval before notifying the user. This is done to not be annoying to the user, but might surprise you as an implementer if you're testing whether it works.```
In our case, the updateCheckInterval is not set and therefore will use the default `1 day`.