### PR TITLE
Add wiki back into GitHub

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,1 +1,3 @@
 _extends: github-apps-config-next
+repository:
+    has_wiki: true


### PR DESCRIPTION
Default for wiki is `false`: https://github.com/Financial-Times/github-apps-config-next/blob/0555987b7a98e259bae54c5ed0f145ef8d9898fa/.github/settings.yml#L14

Enable it again.