### PR TITLE
Expose ebi as a library that can be imported

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@
 	<img alt="Build Status" src="https://circleci.com/gh/Financial-Times/ebi/tree/master.svg?style=svg">
 </a>
 
-A command line tool that searches files within GitHub repositories.
+Searches files within GitHub repositories. It can be used as a command line tool or a library.
 
 Ebi (えび) is [Japanese for prawn/shrimp](https://translate.google.com/#view=home&op=translate&sl=en&tl=ja&text=Prawn), and intends to be a small little tool to crawl through your sea of code on GitHub, finding you nuggets of information.
 
-## Global installation (recommmended)
+## Command Line Usage
+
+### Global installation (recommmended)
 
 `npm install --global ebi`
 
@@ -84,6 +86,75 @@ The output format of the JSON is
 | `search`       | `name`                           | [optional] The search term                                    |
 | `regex`        | `no.*`                           | [optional] The regex used for search (ie, `--regex`)          |
 | `error`        | `404 ERROR: ...`                 | [optional] The error message if the result is of type `error` |
+
+## Library Usage
+
+To use `ebi` as a library in a NodeJS project:
+
+    npm install ebi
+
+Require `ebi`, and run a search:
+
+```javascript
+const {
+  contentsSearch,
+  packageSearch,
+  packageEnginesSearch
+} = require('ebi');
+
+// Get a repository list
+const repoList = [
+  'Financial-Times/ebi'
+];
+
+const { getResults, resultsAsync } = await contentsSearch({
+  filepath: 'package.json',
+  search,       // Optional
+  token,        // Optional
+  regex,        // Optional
+  limit         // Optional
+})(repoList);
+
+// Get results synchronously
+const {
+    allResults,
+    searchMatches,
+    searchNoMatches,
+    searchErrors
+} = await getResults();
+
+// Get results asynchronously
+const allAsyncResults = await Promise.all(
+    resultsAsync.map(promise => {
+        // Need to handle errors eg, if file is not found
+        return promise.catch(e => e);
+    })
+);
+```
+
+Similarly:
+
+```javascript
+const { getResults, resultsAsync } = await packageSearch({
+  search: 'ebi',  // Optional
+  token,          // Optional
+  regex,          // Optional
+  limit           // Optional
+})(repoList);
+```
+
+```javascript
+const { getResults, resultsAsync } = await packageEnginesSearch({
+  search: 'node'  // Optional
+  token,          // Optional
+  regex,          // Optional
+  limit           // Optional
+})(repoList);
+```
+
+See [JSDoc comments](./lib/ebi/ebi-results.js) for descriptions of the parameters. VS Code also has [JSDoc support in the editor](https://code.visualstudio.com/docs/languages/javascript#_jsdoc-support). To turn it on, either put `// @ts-check` on the top of a file or enable the `checkJS` compiler option.
+
+See [examples](./examples) folder for more usage examples.
 
 ## Setting up your GitHub personal access token
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The output format of the JSON is
 
 | Field          | Values                           | Description                                                   |
 | -------------- | -------------------------------- | ------------------------------------------------------------- |
-| `type`         | `match`, `error`                 | Type of result. Non matches will be under `error`             |
+| `type`         | `match`, `no-match`, `error`     | Type of result                                                |
 | `repository`   | `Financial-Times/ebi`            | The full repository path                                      |
 | `filepath`     | `package.json`                   | The filepath searched for                                     |
 | `fileContents` | `{\n \"name\": \"ebi\",\n ... }` | The file contents serialized as a string                      |

--- a/examples/contents-search-example.js
+++ b/examples/contents-search-example.js
@@ -1,0 +1,55 @@
+const { contentsSearch } = require('../lib/ebi');
+
+// NOTE: Assumes you have `GITHUB_PERSONAL_ACCESS_TOKEN` environment variable set
+const { GITHUB_PERSONAL_ACCESS_TOKEN } = process.env;
+
+const repos = [
+	'Financial-Times/ebi',
+	'Financial-Times/tako',
+	'Financial-Times/not-found-error'
+];
+
+const resultsSummary = results =>
+	results.map(({ type, repository }) => `${type}: ${repository}`);
+
+async function contentsResults() {
+	const { getResults } = await contentsSearch({
+		token: GITHUB_PERSONAL_ACCESS_TOKEN,
+		filepath: 'package.json',
+		search: 'ebi'
+	})(repos);
+
+	const {
+		allResults,
+		searchMatches,
+		searchNoMatches,
+		searchErrors
+	} = await getResults();
+
+	console.log('contentsSearch: searchMatches', resultsSummary(searchMatches));
+	console.log(
+		'contentsSearch: searchNoMatches',
+		resultsSummary(searchNoMatches)
+	);
+	console.log('contentsSearch: searchErrors', resultsSummary(searchErrors));
+	console.log('contentsSearch: allResults', resultsSummary(allResults));
+}
+
+async function contentsResultsAsync() {
+	const { resultsAsync } = await contentsSearch({
+		token: GITHUB_PERSONAL_ACCESS_TOKEN,
+		filepath: 'package.json',
+		search: 'ebi'
+	})(repos);
+
+	const allResults = await Promise.all(
+		resultsAsync.map(promise => {
+			return promise.catch(e => e);
+		})
+	);
+
+	console.log('contentsSearchAsync: allResults', resultsSummary(allResults));
+}
+
+contentsResults();
+contentsResultsAsync();

--- a/examples/package-engines-search-example.js
+++ b/examples/package-engines-search-example.js
@@ -1,0 +1,62 @@
+const { packageEnginesSearch } = require('../lib/ebi');
+
+// NOTE: Assumes you have `GITHUB_PERSONAL_ACCESS_TOKEN` environment variable set
+const { GITHUB_PERSONAL_ACCESS_TOKEN } = process.env;
+
+const repos = [
+	'Financial-Times/ebi',
+	'Financial-Times/tako',
+	'Financial-Times/not-found-error'
+];
+
+const resultsSummary = results =>
+	results.map(({ type, repository }) => `${type}: ${repository}`);
+
+async function packageEnginesResults() {
+	const { getResults } = await packageEnginesSearch({
+		token: GITHUB_PERSONAL_ACCESS_TOKEN,
+		search: 'node'
+	})(repos);
+
+	const {
+		allResults,
+		searchMatches,
+		searchNoMatches,
+		searchErrors
+	} = await getResults();
+
+	console.log(
+		'packageEnginesSearch: searchMatches',
+		resultsSummary(searchMatches)
+	);
+	console.log(
+		'packageEnginesSearch: searchNoMatches',
+		resultsSummary(searchNoMatches)
+	);
+	console.log(
+		'packageEnginesSearch: searchErrors',
+		resultsSummary(searchErrors)
+	);
+	console.log('packageEnginesSearch: allResults', resultsSummary(allResults));
+}
+
+async function packageEnginesResultsAsync() {
+	const { resultsAsync } = await packageEnginesSearch({
+		token: GITHUB_PERSONAL_ACCESS_TOKEN,
+		search: 'node'
+	})(repos);
+
+	const allResults = await Promise.all(
+		resultsAsync.map(promise => {
+			return promise.catch(e => e);
+		})
+	);
+
+	console.log(
+		'packageEnginesSearchAsync: allResults',
+		resultsSummary(allResults)
+	);
+}
+
+packageEnginesResults();
+packageEnginesResultsAsync();

--- a/examples/package-search-example.js
+++ b/examples/package-search-example.js
@@ -1,0 +1,53 @@
+const { packageSearch } = require('../lib/ebi');
+
+// NOTE: Assumes you have `GITHUB_PERSONAL_ACCESS_TOKEN` environment variable set
+const { GITHUB_PERSONAL_ACCESS_TOKEN } = process.env;
+
+const repos = [
+	'Financial-Times/ebi',
+	'Financial-Times/tako',
+	'Financial-Times/not-found-error'
+];
+
+const resultsSummary = results =>
+	results.map(({ type, repository }) => `${type}: ${repository}`);
+
+async function packageResults() {
+	const { getResults } = await packageSearch({
+		token: GITHUB_PERSONAL_ACCESS_TOKEN,
+		search: 'ebi'
+	})(repos);
+
+	const {
+		allResults,
+		searchMatches,
+		searchNoMatches,
+		searchErrors
+	} = await getResults();
+
+	console.log('packageSearch: searchMatches', resultsSummary(searchMatches));
+	console.log(
+		'packageSearch: searchNoMatches',
+		resultsSummary(searchNoMatches)
+	);
+	console.log('packageSearch: searchErrors', resultsSummary(searchErrors));
+	console.log('packageSearch: allResults', resultsSummary(allResults));
+}
+
+async function packageResultsAsync() {
+	const { resultsAsync } = await packageSearch({
+		token: GITHUB_PERSONAL_ACCESS_TOKEN,
+		search: 'ebi'
+	})(repos);
+
+	const allResults = await Promise.all(
+		resultsAsync.map(promise => {
+			return promise.catch(e => e);
+		})
+	);
+
+	console.log('packageSearchAsync: allResults', resultsSummary(allResults));
+}
+
+packageResults();
+packageResultsAsync();

--- a/lib/create-result.js
+++ b/lib/create-result.js
@@ -1,3 +1,9 @@
+const RESULT_TYPES = {
+	match: 'match',
+	noMatch: 'no-match',
+	error: 'error'
+};
+
 /**
  * Create result with initial data, then augment with `with*` functions
  * or custom data
@@ -6,27 +12,41 @@ const createResult = initData => (data = {}) => {
 	return Object.assign({}, { ...initData }, data);
 };
 
-const withMatch = data => {
-	const matchResult = createResult({ type: 'match' });
-	return matchResult(data);
-};
-
+const withMatch = createResult({ type: RESULT_TYPES.match });
 const withMatchFileContents = fileContents => {
 	return withMatch({
 		fileContents
 	});
 };
 
+const withNoMatch = createResult({ type: RESULT_TYPES.noMatch });
+const withNoMatchMessage = message => {
+	return withNoMatch({
+		message
+	});
+};
+const withNoMatchMessageFileContents = ({ message, fileContents }) => {
+	return withNoMatch({
+		fileContents,
+		message
+	});
+};
+
 const withErrorMessage = message => {
-	const errorResult = createResult({ type: 'error' });
+	const errorResult = createResult({ type: RESULT_TYPES.error });
 	return errorResult({
 		error: message
 	});
 };
 
 module.exports = {
+	RESULT_TYPES,
+
 	createResult,
 	withMatch,
 	withMatchFileContents,
+	withNoMatch,
+	withNoMatchMessage,
+	withNoMatchMessageFileContents,
 	withErrorMessage
 };

--- a/lib/ebi/contents-search.js
+++ b/lib/ebi/contents-search.js
@@ -6,6 +6,7 @@ const {
 	withNoMatchMessageFileContents,
 	withErrorMessage
 } = require('../../lib/create-result');
+const { getEbiResults } = require('./ebi-results');
 
 exports.contentsSearch = ({
 	filepath,
@@ -28,21 +29,8 @@ exports.contentsSearch = ({
 		filepath
 	});
 
-	const invalidRepos = errors.map(error => {
-		const { repository, line } = error;
-		const result = createResult({
-			search,
-			regex,
-			filepath,
-			repository
-		});
-		const message = `ERROR: invalid repository '${repository}' on line ${line}`;
-		const output = result(withErrorMessage(message));
-		return Promise.reject(output);
-	});
-
 	// get the contents of <filepath> for each repository
-	const allRepos = repositories.map(repository => {
+	const searchResults = repositories.map(repository => {
 		const result = createResult({
 			search,
 			regex,
@@ -89,5 +77,11 @@ exports.contentsSearch = ({
 			});
 	});
 
-	return invalidRepos.concat(allRepos);
+	return getEbiResults({
+		errors,
+		search,
+		regex,
+		filepath,
+		searchResults
+	});
 };

--- a/lib/ebi/contents-search.js
+++ b/lib/ebi/contents-search.js
@@ -1,0 +1,86 @@
+const getRepositories = require('../../lib/get-repositories');
+const getContents = require('../../lib/get-contents');
+const {
+	createResult,
+	withMatchFileContents,
+	withErrorMessage
+} = require('../../lib/create-result');
+
+exports.contentsSearch = ({
+	filepath,
+	token,
+	search,
+	regex,
+	limit
+} = {}) => async repoList => {
+	const { errors, repositories } = await getRepositories({
+		limit,
+		repoList
+	});
+
+	const getPathContents = getContents({
+		githubToken: token,
+		filepath
+	});
+
+	const invalidRepos = errors.map(error => {
+		const { repository, line } = error;
+		const result = createResult({
+			search,
+			regex,
+			filepath,
+			repository
+		});
+		const message = `ERROR: invalid repository '${repository}' on line ${line}`;
+		const output = result(withErrorMessage(message));
+		return Promise.reject(output);
+	});
+
+	// get the contents of <filepath> for each repository
+	const allRepos = repositories.map(repository => {
+		const result = createResult({
+			search,
+			regex,
+			filepath,
+			repository
+		});
+		return getPathContents(repository)
+			.then(contents => {
+				const noSearch = !search;
+				const containsSearchItem = contents.includes(search);
+				let output;
+
+				if (regex) {
+					const regExp = new RegExp(regex);
+					const hasMatch = contents.match(regExp);
+
+					if (hasMatch) {
+						output = result(withMatchFileContents(contents));
+					} else {
+						output = result(
+							withErrorMessage(
+								`INFO: '${filepath}' has no match for '${regExp}' in '${repository}'`
+							)
+						);
+					}
+				} else if (noSearch || containsSearchItem) {
+					output = result(withMatchFileContents(contents));
+				} else {
+					output = result(
+						withErrorMessage(
+							`INFO: '${filepath}' has no match for '${search}' in '${repository}'`
+						)
+					);
+				}
+
+				return output;
+			})
+			.catch(error => {
+				const { message } = error;
+				const output = result(withErrorMessage(message));
+				return Promise.reject(output);
+			});
+	});
+
+	return invalidRepos.concat(allRepos);
+};

--- a/lib/ebi/contents-search.js
+++ b/lib/ebi/contents-search.js
@@ -3,6 +3,7 @@ const getContents = require('../../lib/get-contents');
 const {
 	createResult,
 	withMatchFileContents,
+	withNoMatchMessageFileContents,
 	withErrorMessage
 } = require('../../lib/create-result');
 
@@ -58,18 +59,20 @@ exports.contentsSearch = ({
 						output = result(withMatchFileContents(contents));
 					} else {
 						output = result(
-							withErrorMessage(
-								`INFO: '${filepath}' has no match for '${regExp}' in '${repository}'`
-							)
+							withNoMatchMessageFileContents({
+								message: `INFO: '${filepath}' has no match for '${regExp}' in '${repository}'`,
+								fileContents: contents
+							})
 						);
 					}
 				} else if (noSearch || containsSearchItem) {
 					output = result(withMatchFileContents(contents));
 				} else {
 					output = result(
-						withErrorMessage(
-							`INFO: '${filepath}' has no match for '${search}' in '${repository}'`
-						)
+						withNoMatchMessageFileContents({
+							message: `INFO: '${filepath}' has no match for '${search}' in '${repository}'`,
+							fileContents: contents
+						})
 					);
 				}
 

--- a/lib/ebi/contents-search.js
+++ b/lib/ebi/contents-search.js
@@ -14,6 +14,10 @@ exports.contentsSearch = ({
 	regex,
 	limit
 } = {}) => async repoList => {
+	if (!filepath) {
+		throw new Error("'filepath' is required for contents search");
+	}
+
 	const { errors, repositories } = await getRepositories({
 		limit,
 		repoList

--- a/lib/ebi/contents-search.js
+++ b/lib/ebi/contents-search.js
@@ -8,6 +8,27 @@ const {
 } = require('../../lib/create-result');
 const { getEbiResults } = require('./ebi-results');
 
+/**
+ * @typedef {import('./ebi-results').EbiResultsObject} EbiResultsObject
+ */
+
+/**
+ * Search configuration
+ *
+ * @typedef {Object} Config
+ * @property {string} filepath The filepath to search for
+ * @property {string} [token] GitHub API token
+ * @property {string} [search] Search string
+ * @property {string} [regex] Regular expression for searching. Overrides `search` property
+ * @property {number} [limit] Limit the number of repositories to search for
+ */
+
+/**
+ * Search the contents of a file in GitHub repositories
+ *
+ * @param {Config} [config={}]
+ * @returns {(repoList: string[]) => EbiResultsObject)}
+ */
 exports.contentsSearch = ({
 	filepath,
 	token,

--- a/lib/ebi/ebi-log.js
+++ b/lib/ebi/ebi-log.js
@@ -1,4 +1,13 @@
 const { logText, logJson } = require('../log-result');
+const { withErrorMessage } = require('../create-result');
+
+const logOutput = ({ json, output }) => {
+	if (json) {
+		logJson(output);
+	} else {
+		logText(output);
+	}
+};
 
 /*
  * Log ebi searches
@@ -8,7 +17,16 @@ const { logText, logJson } = require('../log-result');
  * @param {array} arrayList - repository list
  */
 exports.ebiLog = ({ ebiSearch, json }) => async repoList => {
-	const results = await ebiSearch(repoList);
+	let results;
+
+	try {
+		results = await ebiSearch(repoList);
+	} catch ({ message }) {
+		return logOutput({
+			json,
+			output: withErrorMessage(`ERROR: ${message}`)
+		});
+	}
 
 	const allRepos = results.map(async result => {
 		let output;
@@ -18,11 +36,7 @@ exports.ebiLog = ({ ebiSearch, json }) => async repoList => {
 			output = error;
 		}
 
-		if (json) {
-			logJson(output);
-		} else {
-			logText(output);
-		}
+		logOutput({ json, output });
 	});
 
 	return Promise.all(allRepos);

--- a/lib/ebi/ebi-log.js
+++ b/lib/ebi/ebi-log.js
@@ -16,28 +16,20 @@ const logOutput = ({ json, output }) => {
  * @param {boolean} json - whether to log in json or plain text
  * @param {array} arrayList - repository list
  */
-exports.ebiLog = ({ ebiSearch, json }) => async repoList => {
-	let results;
-
-	try {
-		results = await ebiSearch(repoList);
-	} catch ({ message }) {
-		return logOutput({
-			json,
-			output: withErrorMessage(`ERROR: ${message}`)
-		});
-	}
-
-	const allRepos = results.map(async result => {
-		let output;
-		try {
-			output = await result;
-		} catch (error) {
-			output = error;
-		}
-
-		logOutput({ json, output });
-	});
-
-	return Promise.all(allRepos);
+exports.ebiLog = ({ ebiSearch, json }) => repoList => {
+	return ebiSearch(repoList)
+		.then(({ resultsAsync }) => {
+			const results = resultsAsync.map(result => {
+				return result
+					.then(output => logOutput({ json, output }))
+					.catch(error => logOutput({ json, output: error }));
+			});
+			return Promise.all(results);
+		})
+		.catch(({ message }) =>
+			logOutput({
+				json,
+				output: withErrorMessage(`ERROR: ${message}`)
+			})
+		);
 };

--- a/lib/ebi/ebi-log.js
+++ b/lib/ebi/ebi-log.js
@@ -1,0 +1,29 @@
+const { logText, logJson } = require('../log-result');
+
+/*
+ * Log ebi searches
+ *
+ * @param {function} ebiSearch - ebi search function in the form `searchFn({ someConfig })`
+ * @param {boolean} json - whether to log in json or plain text
+ * @param {array} arrayList - repository list
+ */
+exports.ebiLog = ({ ebiSearch, json }) => async repoList => {
+	const results = await ebiSearch(repoList);
+
+	const allRepos = results.map(async result => {
+		let output;
+		try {
+			output = await result;
+		} catch (error) {
+			output = error;
+		}
+
+		if (json) {
+			logJson(output);
+		} else {
+			logText(output);
+		}
+	});
+
+	return Promise.all(allRepos);
+};

--- a/lib/ebi/ebi-results.js
+++ b/lib/ebi/ebi-results.js
@@ -1,7 +1,40 @@
 const { createResult, withErrorMessage } = require('../../lib/create-result');
 
 /**
- * Return a function that returns ebi results in a synchronous format
+ * Ebi result
+ *
+ * @typedef {Object} EbiResult
+ * @property {'match'|'no-match'|'error'} type Type of result
+ * @property {string} repository Full repository path
+ * @property {string} filepath The filepath searched for
+ * @property {string} fileContents The file contents serialized as a string
+ * @property {string} [search] The search term
+ * @property {string} [regex] The regex used for search
+ * @property {string} [error] The error message if the result is of type `error`
+ * @property {string} [message] Extra information about the result
+ */
+
+/**
+ * Ebi results
+ *
+ * @typedef {Object} EbiResults
+ * @property {EbiResult[]} allResults All search results
+ * @property {EbiResult[]} searchMatches All search results that match
+ * @property {EbiResult[]} searchNoMatches All search results that do not match
+ * @property {EbiResult[]} searchErrors All search errors
+ */
+
+/**
+ * Ebi results function
+ *
+ * @typedef {() => EbiResults} EbiResultsFunction
+ */
+
+/**
+ * Get a function that returns ebi results in a synchronous format
+ *
+ * @param {Promise<EbiResult>[]} resultsAsync An array of asynchronous ebi results
+ * @returns {EbiResultsFunction}
  */
 const getSyncResults = resultsAsync => async () => {
 	const allResults = await Promise.all(
@@ -25,7 +58,29 @@ const getSyncResults = resultsAsync => async () => {
 };
 
 /**
+ * Ebi results input
+ *
+ * @typedef {Object} EbiResultsInput
+ * @property {Array} errors
+ * @property {string} [search]
+ * @property {string} [regex]
+ * @property {string} filepath
+ * @property {Promise<EbiResult>[]} searchResults
+ */
+
+/**
+ * Ebi results object
+ *
+ * @typedef {Object} EbiResultsObject
+ * @property {Promise<EbiResult>[]} resultsAsync An array of asynchronous ebi results
+ * @property {EbiResultsFunction} getResults Function to get synchronous ebi results
+ */
+
+/**
  * Get ebi results in an asynchronous and synchronous format
+ *
+ * @param {EbiResultsInput} config
+ * @returns {EbiResultsObject}
  */
 exports.getEbiResults = ({
 	errors,

--- a/lib/ebi/ebi-results.js
+++ b/lib/ebi/ebi-results.js
@@ -1,0 +1,55 @@
+const { createResult, withErrorMessage } = require('../../lib/create-result');
+
+/**
+ * Return a function that returns ebi results in a synchronous format
+ */
+const getSyncResults = resultsAsync => async () => {
+	const allResults = await Promise.all(
+		resultsAsync.map(promise => {
+			return promise.catch(e => e);
+		})
+	);
+
+	const searchMatches = allResults.filter(({ type }) => type === 'match');
+	const searchNoMatches = allResults.filter(
+		({ type }) => type === 'no-match'
+	);
+	const searchErrors = allResults.filter(({ type }) => type === 'error');
+
+	return {
+		allResults,
+		searchMatches,
+		searchNoMatches,
+		searchErrors
+	};
+};
+
+/**
+ * Get ebi results in an asynchronous and synchronous format
+ */
+exports.getEbiResults = ({
+	errors,
+	search,
+	regex,
+	filepath,
+	searchResults
+}) => {
+	const invalidRepos = errors.map(error => {
+		const { repository, line } = error;
+		const result = createResult({
+			search,
+			regex,
+			filepath,
+			repository
+		});
+		const message = `ERROR: invalid repository '${repository}' on line ${line}`;
+		const output = result(withErrorMessage(message));
+		return Promise.reject(output);
+	});
+
+	const resultsAsync = invalidRepos.concat(searchResults);
+	return {
+		resultsAsync,
+		getResults: getSyncResults(resultsAsync)
+	};
+};

--- a/lib/ebi/index.js
+++ b/lib/ebi/index.js
@@ -1,0 +1,9 @@
+const { contentsSearch } = require('./contents-search');
+const { packageSearch } = require('./package-search');
+const { packageEnginesSearch } = require('./package-engines-search');
+
+module.exports = {
+	contentsSearch,
+	packageSearch,
+	packageEnginesSearch
+};

--- a/lib/ebi/package-engines-search.js
+++ b/lib/ebi/package-engines-search.js
@@ -1,0 +1,127 @@
+const getRepositories = require('../../lib/get-repositories');
+const getContents = require('../../lib/get-contents');
+const { createResult, withErrorMessage } = require('../../lib/create-result');
+
+const { findMatchedKeyValuePairs } = require('../../lib/object-utils');
+
+const { withMatch } = require('../../lib/create-result');
+
+const processJson = content => {
+	return JSON.parse(content);
+};
+
+// Report all engines in a tab separated format
+// eg, "node@8.13.0  npm@6.8.0"
+const enginesReport = engines => {
+	return Object.keys(engines)
+		.map(name => `${name}@${engines[name]}`)
+		.join('\t');
+};
+
+const getJson = ({ filepath, repository }) => data => {
+	try {
+		return processJson(data);
+	} catch (error) {
+		throw new Error(
+			`JSON PARSE ERROR: ${filepath} parse error in '${repository}'`
+		);
+	}
+};
+
+const throwIfNoEngines = ({ filepath, repository }) => (json = {}) => {
+	const { engines } = json;
+	if (!engines) {
+		throw new Error(
+			`INFO: engines field not found in '${filepath}' in '${repository}'`
+		);
+	}
+	return engines;
+};
+
+const filterSearch = ({ search, regex }) => engines => {
+	if (regex) {
+		return findMatchedKeyValuePairs(engines, value => {
+			return value.match(new RegExp(regex));
+		});
+	} else if (search) {
+		return findMatchedKeyValuePairs(engines, value =>
+			value.includes(search)
+		);
+	} else {
+		return engines;
+	}
+};
+
+exports.packageEnginesSearch = ({
+	token,
+	limit,
+	search,
+	regex
+} = {}) => async repoList => {
+	const { errors, repositories } = await getRepositories({ limit, repoList });
+	const filepath = 'package.json';
+
+	const getPackageJsonFile = getContents({
+		githubToken: token,
+		filepath
+	});
+
+	const invalidRepos = errors.map(error => {
+		const { repository, line } = error;
+		const result = createResult({
+			search,
+			regex,
+			filepath,
+			repository
+		});
+		const message = `ERROR: invalid repository '${repository}' on line ${line}`;
+		const output = result(withErrorMessage(message));
+		return Promise.reject(output);
+	});
+
+	const allRepos = repositories.map(repository => {
+		const baseResult = {
+			search,
+			regex,
+			filepath,
+			repository
+		};
+		let result = createResult(baseResult);
+		return getPackageJsonFile(repository)
+			.then(fileContents => {
+				result = createResult({ ...baseResult, fileContents });
+				return fileContents;
+			})
+			.then(getJson({ filepath, repository }))
+			.then(throwIfNoEngines({ filepath, repository }))
+			.then(filterSearch({ search, regex }))
+			.then(engines => {
+				const hasEngines = !!Object.keys(engines).length;
+				let output;
+				if (hasEngines) {
+					output = result(
+						withMatch({
+							engines,
+							textSuffix: enginesReport(engines)
+						})
+					);
+				} else {
+					output = result(
+						withErrorMessage(
+							`INFO: '${filepath}' has no match for '${regex ||
+								search}' in '${repository}'`
+						)
+					);
+				}
+
+				return output;
+			})
+			.catch(error => {
+				const { message } = error;
+				const output = result(withErrorMessage(message));
+				return Promise.reject(output);
+			});
+	});
+
+	return invalidRepos.concat(allRepos);
+};

--- a/lib/ebi/package-engines-search.js
+++ b/lib/ebi/package-engines-search.js
@@ -53,6 +53,26 @@ const filterSearch = ({ search, regex }) => engines => {
 	}
 };
 
+/**
+ * @typedef {import('./ebi-results').EbiResultsObject} EbiResultsObject
+ */
+
+/**
+ * Search configuration
+ *
+ * @typedef {Object} Config
+ * @property {string} [token] GitHub API token
+ * @property {string} [search] Search string
+ * @property {string} [regex] Regular expression for searching. Overrides `search` property
+ * @property {number} [limit] Limit the number of repositories to search for
+ */
+
+/**
+ * Search the contents of the `engines` field in the `package.json` file in GitHub repositories
+ *
+ * @param {Config} [config={}]
+ * @returns {(repoList: string[]) => EbiResultsObject)}
+ */
 exports.packageEnginesSearch = ({
 	token,
 	limit,

--- a/lib/ebi/package-engines-search.js
+++ b/lib/ebi/package-engines-search.js
@@ -1,6 +1,7 @@
 const getRepositories = require('../../lib/get-repositories');
 const getContents = require('../../lib/get-contents');
 const { createResult, withErrorMessage } = require('../../lib/create-result');
+const { getEbiResults } = require('./ebi-results');
 
 const { findMatchedKeyValuePairs } = require('../../lib/object-utils');
 
@@ -66,20 +67,7 @@ exports.packageEnginesSearch = ({
 		filepath
 	});
 
-	const invalidRepos = errors.map(error => {
-		const { repository, line } = error;
-		const result = createResult({
-			search,
-			regex,
-			filepath,
-			repository
-		});
-		const message = `ERROR: invalid repository '${repository}' on line ${line}`;
-		const output = result(withErrorMessage(message));
-		return Promise.reject(output);
-	});
-
-	const allRepos = repositories.map(repository => {
+	const searchResults = repositories.map(repository => {
 		const baseResult = {
 			search,
 			regex,
@@ -123,5 +111,11 @@ exports.packageEnginesSearch = ({
 			});
 	});
 
-	return invalidRepos.concat(allRepos);
+	return getEbiResults({
+		errors,
+		search,
+		regex,
+		filepath,
+		searchResults
+	});
 };

--- a/lib/ebi/package-engines-search.js
+++ b/lib/ebi/package-engines-search.js
@@ -4,7 +4,7 @@ const { createResult, withErrorMessage } = require('../../lib/create-result');
 
 const { findMatchedKeyValuePairs } = require('../../lib/object-utils');
 
-const { withMatch } = require('../../lib/create-result');
+const { withMatch, withNoMatchMessage } = require('../../lib/create-result');
 
 const processJson = content => {
 	return JSON.parse(content);
@@ -107,7 +107,7 @@ exports.packageEnginesSearch = ({
 					);
 				} else {
 					output = result(
-						withErrorMessage(
+						withNoMatchMessage(
 							`INFO: '${filepath}' has no match for '${regex ||
 								search}' in '${repository}'`
 						)

--- a/lib/ebi/package-search.js
+++ b/lib/ebi/package-search.js
@@ -6,6 +6,7 @@ const {
 	withNoMatchMessageFileContents,
 	withErrorMessage
 } = require('../../lib/create-result');
+const { getEbiResults } = require('./ebi-results');
 
 exports.packageSearch = ({
 	token,
@@ -21,20 +22,7 @@ exports.packageSearch = ({
 		filepath
 	});
 
-	const invalidRepos = errors.map(error => {
-		const { repository, line } = error;
-		const result = createResult({
-			search,
-			regex,
-			filepath,
-			repository
-		});
-		const message = `ERROR: invalid repository '${repository}' on line ${line}`;
-		const output = result(withErrorMessage(message));
-		return Promise.reject(output);
-	});
-
-	const allRepos = repositories.map(repository => {
+	const searchResults = repositories.map(repository => {
 		const result = createResult({
 			search,
 			regex,
@@ -82,5 +70,11 @@ exports.packageSearch = ({
 			});
 	});
 
-	return invalidRepos.concat(allRepos);
+	return getEbiResults({
+		errors,
+		search,
+		regex,
+		filepath,
+		searchResults
+	});
 };

--- a/lib/ebi/package-search.js
+++ b/lib/ebi/package-search.js
@@ -1,0 +1,83 @@
+const getRepositories = require('../../lib/get-repositories');
+const getContents = require('../../lib/get-contents');
+const {
+	createResult,
+	withMatchFileContents,
+	withErrorMessage
+} = require('../../lib/create-result');
+
+exports.packageSearch = ({
+	token,
+	search,
+	regex,
+	limit
+} = {}) => async repoList => {
+	const { errors, repositories } = await getRepositories({ limit, repoList });
+	const filepath = 'package.json';
+
+	const getPackageJson = getContents({
+		githubToken: token,
+		filepath
+	});
+
+	const invalidRepos = errors.map(error => {
+		const { repository, line } = error;
+		const result = createResult({
+			search,
+			regex,
+			filepath,
+			repository
+		});
+		const message = `ERROR: invalid repository '${repository}' on line ${line}`;
+		const output = result(withErrorMessage(message));
+		return Promise.reject(output);
+	});
+
+	const allRepos = repositories.map(repository => {
+		const result = createResult({
+			search,
+			regex,
+			filepath,
+			repository
+		});
+		return getPackageJson(repository)
+			.then(contents => {
+				const noSearch = !search;
+				const containsSearchItem = contents.includes(search);
+				let output;
+
+				if (regex) {
+					const regExp = new RegExp(regex);
+					const hasMatch = contents.match(regExp);
+
+					if (hasMatch) {
+						output = result(withMatchFileContents(contents));
+					} else {
+						output = result(
+							withErrorMessage(
+								`INFO: '${filepath}' has no match for '${regExp}' in '${repository}'`
+							)
+						);
+					}
+				} else if (noSearch || containsSearchItem) {
+					output = result(withMatchFileContents(contents));
+				} else {
+					output = result(
+						withErrorMessage(
+							`INFO: '${filepath}' has no match for '${search}' in '${repository}'`
+						)
+					);
+				}
+
+				return output;
+			})
+
+			.catch(error => {
+				const { message } = error;
+				const output = result(withErrorMessage(message));
+				return Promise.reject(output);
+			});
+	});
+
+	return invalidRepos.concat(allRepos);
+};

--- a/lib/ebi/package-search.js
+++ b/lib/ebi/package-search.js
@@ -8,6 +8,26 @@ const {
 } = require('../../lib/create-result');
 const { getEbiResults } = require('./ebi-results');
 
+/**
+ * @typedef {import('./ebi-results').EbiResultsObject} EbiResultsObject
+ */
+
+/**
+ * Search configuration
+ *
+ * @typedef {Object} Config
+ * @property {string} [token] GitHub API token
+ * @property {string} [search] Search string
+ * @property {string} [regex] Regular expression for searching. Overrides `search` property
+ * @property {number} [limit] Limit the number of repositories to search for
+ */
+
+/**
+ * Search the contents of a `package.json` file in GitHub repositories
+ *
+ * @param {Config} [config={}]
+ * @returns {(repoList: string[]) => EbiResultsObject)}
+ */
 exports.packageSearch = ({
 	token,
 	search,

--- a/lib/ebi/package-search.js
+++ b/lib/ebi/package-search.js
@@ -3,6 +3,7 @@ const getContents = require('../../lib/get-contents');
 const {
 	createResult,
 	withMatchFileContents,
+	withNoMatchMessageFileContents,
 	withErrorMessage
 } = require('../../lib/create-result');
 
@@ -54,18 +55,20 @@ exports.packageSearch = ({
 						output = result(withMatchFileContents(contents));
 					} else {
 						output = result(
-							withErrorMessage(
-								`INFO: '${filepath}' has no match for '${regExp}' in '${repository}'`
-							)
+							withNoMatchMessageFileContents({
+								message: `INFO: '${filepath}' has no match for '${regExp}' in '${repository}'`,
+								fileContents: contents
+							})
 						);
 					}
 				} else if (noSearch || containsSearchItem) {
 					output = result(withMatchFileContents(contents));
 				} else {
 					output = result(
-						withErrorMessage(
-							`INFO: '${filepath}' has no match for '${search}' in '${repository}'`
-						)
+						withNoMatchMessageFileContents({
+							message: `INFO: '${filepath}' has no match for '${search}' in '${repository}'`,
+							fileContents: contents
+						})
 					);
 				}
 

--- a/lib/log-result.js
+++ b/lib/log-result.js
@@ -1,21 +1,10 @@
 /*eslint no-console: ["error", { allow: ["log", "error"] }] */
 const logText = result => {
-	const { type, repository, error } = result;
+	const { type, repository, error, textSuffix } = result;
 	if (type === 'error') {
 		console.error(error);
 	} else {
-		console.log(repository);
-	}
-};
-
-const logTextWithSuffix = suffixFn => result => {
-	const { type, repository, error } = result;
-
-	if (type === 'error') {
-		console.error(error);
-	} else {
-		const suffixStr = suffixFn ? ` ${suffixFn(result)}` : '';
-		console.log(`${repository}${suffixStr}`);
+		console.log(`${repository}${!!textSuffix ? ` ${textSuffix}` : ''}`);
 	}
 };
 
@@ -27,6 +16,5 @@ const logJson = result => {
 
 module.exports = {
 	logText,
-	logTextWithSuffix,
 	logJson
 };

--- a/lib/log-result.js
+++ b/lib/log-result.js
@@ -1,8 +1,13 @@
 /*eslint no-console: ["error", { allow: ["log", "error"] }] */
+
+const { RESULT_TYPES } = require('./create-result');
+
 const logText = result => {
-	const { type, repository, error, textSuffix } = result;
-	if (type === 'error') {
+	const { type, repository, error, message, textSuffix } = result;
+	if (type === RESULT_TYPES.error) {
 		console.error(error);
+	} else if (type === RESULT_TYPES.noMatch) {
+		console.error(message);
 	} else {
 		console.log(`${repository}${!!textSuffix ? ` ${textSuffix}` : ''}`);
 	}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"version": "0.0.0",
 	"description": "A command line tool that searches files within GitHub repositories",
 	"bin": "./bin/ebi.js",
+	"main": "./lib/ebi/index.js",
 	"scripts": {
 		"lint": "eslint *.js src/ lib/ test/",
 		"lint-fix": "eslint --fix *.js src/ lib/ test/",

--- a/src/commands/contents.js
+++ b/src/commands/contents.js
@@ -36,7 +36,7 @@ exports.builder = yargs => {
 		});
 };
 
-exports.handler = async ({
+exports.handler = ({
 	filepath,
 	token,
 	search,

--- a/src/commands/package-engines.js
+++ b/src/commands/package-engines.js
@@ -18,7 +18,7 @@ const {
 	withMatch,
 	withErrorMessage
 } = require('../../lib/create-result');
-const { logText, logTextWithSuffix, logJson } = require('../../lib/log-result');
+const { logText, logJson } = require('../../lib/log-result');
 
 exports.command = 'package:engines [search] [repo..]';
 exports.desc = 'Search `engines` field inside the `package.json` file';
@@ -128,7 +128,12 @@ exports.handler = async function(argv = {}) {
 				const hasEngines = !!Object.keys(engines).length;
 				let output;
 				if (hasEngines) {
-					output = result(withMatch({ engines }));
+					output = result(
+						withMatch({
+							engines,
+							textSuffix: enginesReport(engines)
+						})
+					);
 				} else {
 					output = result(
 						withErrorMessage(
@@ -140,15 +145,7 @@ exports.handler = async function(argv = {}) {
 
 				return output;
 			})
-			.then(result => {
-				if (json) {
-					return logJson(result);
-				} else {
-					return logTextWithSuffix(({ engines }) =>
-						enginesReport(engines)
-					)(result);
-				}
-			})
+			.then(result => (json ? logJson(result) : logText(result)))
 			.catch(error => {
 				const { message } = error;
 				const output = result(withErrorMessage(message));

--- a/src/commands/package-engines.js
+++ b/src/commands/package-engines.js
@@ -32,7 +32,7 @@ exports.builder = yargs => {
 	});
 };
 
-exports.handler = async function({
+exports.handler = function({
 	token,
 	limit,
 	search,

--- a/src/commands/package.js
+++ b/src/commands/package.js
@@ -31,7 +31,7 @@ exports.builder = yargs => {
 	});
 };
 
-exports.handler = async function({
+exports.handler = function({
 	token,
 	search,
 	limit,

--- a/test/commands/contents.test.js
+++ b/test/commands/contents.test.js
@@ -106,13 +106,15 @@ describe('contents command handler', () => {
 		expect(console.error).not.toBeCalled();
 	});
 
-	test('no arguments does nothing', async () => {
+	test('no arguments errors with filepath required', async () => {
 		await initializeContentsHandler({
 			inputType: INPUT_TYPES.STDIN
 		});
 
 		expect(console.log).not.toBeCalled();
-		expect(console.error).not.toBeCalled();
+		expect(console.error).toBeCalledWith(
+			expect.stringContaining(`'filepath' is required`)
+		);
 	});
 
 	test('when contents handler is called with valid <file> and <search> values, a list of repositories are logged', async () => {

--- a/test/commands/contents.test.js
+++ b/test/commands/contents.test.js
@@ -353,6 +353,34 @@ describe('json output', () => {
 		});
 	});
 
+	test('shows json with no match', async () => {
+		nockScope.get(`/${repo}/contents/Procfile`).reply(200, {
+			type: 'file',
+			content: base64Encode('web: node 1234.js'),
+			path: 'Procfile'
+		});
+
+		await initializeContentsHandler({
+			repos: [repo],
+			args: {
+				json: true,
+				filepath: 'Procfile',
+				search: 'something-else'
+			},
+			inputType: INPUT_TYPES.STDIN
+		});
+
+		const log = JSON.parse(console.log.mock.calls[0][0]);
+		expect(log).toEqual({
+			type: 'no-match',
+			filepath: 'Procfile',
+			search: 'something-else',
+			repository: repo,
+			message: expect.stringContaining('no match'),
+			fileContents: 'web: node 1234.js'
+		});
+	});
+
 	test('shows json error', async () => {
 		nockScope.get(`/${repo}/contents/Procfile`).reply(404);
 

--- a/test/commands/package-engines.test.js
+++ b/test/commands/package-engines.test.js
@@ -489,6 +489,29 @@ describe('json output', () => {
 		});
 	});
 
+	test('shows json with no engines match', async () => {
+		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
+			type: 'file',
+			content: base64EncodeObj(packageJson),
+			path: 'package.json'
+		});
+
+		await initializeHandlerForStdin({
+			repos: [repo],
+			args: { json: true, search: 'something-else' }
+		});
+
+		const log = JSON.parse(console.log.mock.calls[0][0]);
+		expect(log).toEqual({
+			type: 'no-match',
+			filepath: 'package.json',
+			search: 'something-else',
+			fileContents: JSON.stringify(packageJson),
+			repository: repo,
+			message: expect.stringContaining('no match')
+		});
+	});
+
 	test('shows json with error', async () => {
 		nockScope.get(`/${repo}/contents/package.json`).reply(404);
 

--- a/test/commands/package-engines.test.js
+++ b/test/commands/package-engines.test.js
@@ -433,6 +433,7 @@ describe('json output', () => {
 		const log = JSON.parse(console.log.mock.calls[0][0]);
 		expect(log).toEqual({
 			type: 'match',
+			textSuffix: 'node@~10.15.0',
 			filepath: 'package.json',
 			engines: packageJson.engines,
 			fileContents: JSON.stringify(packageJson),
@@ -455,6 +456,7 @@ describe('json output', () => {
 		const log = JSON.parse(console.log.mock.calls[0][0]);
 		expect(log).toEqual({
 			type: 'match',
+			textSuffix: 'node@~10.15.0',
 			filepath: 'package.json',
 			search: 'node',
 			engines: packageJson.engines,
@@ -478,6 +480,7 @@ describe('json output', () => {
 		const log = JSON.parse(console.log.mock.calls[0][0]);
 		expect(log).toEqual({
 			type: 'match',
+			textSuffix: 'node@~10.15.0',
 			filepath: 'package.json',
 			regex: 'no.*',
 			engines: packageJson.engines,

--- a/test/commands/package.test.js
+++ b/test/commands/package.test.js
@@ -305,6 +305,29 @@ describe('json output', () => {
 		});
 	});
 
+	test('shows json with no match', async () => {
+		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
+			type: 'file',
+			content: base64EncodeObj(packageJson),
+			path: 'package.json'
+		});
+
+		await initializeHandlerForStdin({
+			repos: [repo],
+			args: { search: 'something-else', json: true }
+		});
+
+		const log = JSON.parse(console.log.mock.calls[0][0]);
+		expect(log).toEqual({
+			type: 'no-match',
+			filepath: 'package.json',
+			search: 'something-else',
+			repository: repo,
+			fileContents: JSON.stringify(packageJson),
+			message: expect.stringContaining('no match')
+		});
+	});
+
 	test('shows json error', async () => {
 		nockScope.get(`/${repo}/contents/package.json`).reply(404);
 

--- a/test/lib/ebi/contents-search.test.js
+++ b/test/lib/ebi/contents-search.test.js
@@ -1,0 +1,154 @@
+const nock = require('nock');
+
+const { base64Encode } = require('../../helpers/base64');
+const { contentsSearch } = require('../../../lib/ebi/contents-search');
+
+let nockScope;
+let initialTTY;
+
+beforeAll(() => {
+	// Set isTTY to `true`, so that standard input is ignored
+	initialTTY = process.stdin.isTTY;
+	process.stdin.isTTY = true;
+});
+
+beforeEach(() => {
+	nockScope = nock('https://api.github.com/repos');
+});
+
+afterEach(() => {
+	nock.cleanAll();
+});
+
+afterAll(() => {
+	process.stdin.isTTY = initialTTY;
+});
+
+describe('contentsSearch', () => {
+	test('empty filepath', async () => {
+		const repo = 'Financial-Times/ebi';
+		await expect(contentsSearch()([repo])).rejects.toThrow(
+			/'filepath' is required/
+		);
+	});
+
+	test('search results found', async () => {
+		const repo = 'Financial-Times/ebi';
+		nockScope.get(`/${repo}/contents/Procfile`).reply(200, {
+			type: 'file',
+			content: base64Encode('web: n-cluster server/init.js'),
+			path: 'Procfile'
+		});
+
+		const ebiSearch = contentsSearch({
+			search: 'web:',
+			filepath: 'Procfile'
+		});
+		const [result] = await ebiSearch([repo]);
+
+		await expect(result).resolves.toEqual({
+			filepath: 'Procfile',
+			fileContents: 'web: n-cluster server/init.js',
+			regex: undefined,
+			repository: 'Financial-Times/ebi',
+			search: 'web:',
+			type: 'match'
+		});
+	});
+
+	test('regex results found', async () => {
+		const repo = 'Financial-Times/ebi';
+		nockScope.get(`/${repo}/contents/Procfile`).reply(200, {
+			type: 'file',
+			content: base64Encode('web: n-cluster server/init.js'),
+			path: 'Procfile'
+		});
+
+		const ebiSearch = contentsSearch({
+			regex: 'w..:',
+			filepath: 'Procfile'
+		});
+		const [result] = await ebiSearch([repo]);
+
+		await expect(result).resolves.toEqual({
+			filepath: 'Procfile',
+			fileContents: 'web: n-cluster server/init.js',
+			regex: 'w..:',
+			repository: 'Financial-Times/ebi',
+			search: undefined,
+			type: 'match'
+		});
+	});
+
+	test('regex used if search is present', async () => {
+		const repo = 'Financial-Times/ebi';
+		nockScope.get(`/${repo}/contents/Procfile`).reply(200, {
+			type: 'file',
+			content: base64Encode('web: n-cluster server/init.js'),
+			path: 'Procfile'
+		});
+
+		const ebiSearch = contentsSearch({
+			regex: 'w..:',
+			search: 'nope',
+			filepath: 'Procfile'
+		});
+		const [result] = await ebiSearch([repo]);
+
+		await expect(result).resolves.toEqual({
+			filepath: 'Procfile',
+			fileContents: 'web: n-cluster server/init.js',
+			regex: 'w..:',
+			repository: 'Financial-Times/ebi',
+			search: 'nope',
+			type: 'match'
+		});
+	});
+
+	test('results not found', async () => {
+		const repo = 'Financial-Times/ebi';
+		nockScope.get(`/${repo}/contents/Procfile`).reply(200, {
+			type: 'file',
+			content: base64Encode('web: n-cluster server/init.js'),
+			path: 'Procfile'
+		});
+
+		const ebiSearch = contentsSearch({
+			search: 'node',
+			filepath: 'Procfile'
+		});
+		const [result] = await ebiSearch([repo]);
+
+		await expect(result).resolves.toEqual({
+			message:
+				"INFO: 'Procfile' has no match for 'node' in 'Financial-Times/ebi'",
+			filepath: 'Procfile',
+			fileContents: 'web: n-cluster server/init.js',
+			regex: undefined,
+			repository: 'Financial-Times/ebi',
+			search: 'node',
+			type: 'no-match'
+		});
+	});
+
+	test('file not found', async () => {
+		const repo = 'Financial-Times/ebi';
+		nockScope.get(`/${repo}/contents/Procfile`).reply(404);
+
+		const ebiSearch = contentsSearch({
+			search: 'web:',
+			filepath: 'Procfile'
+		});
+		const [result] = await ebiSearch([repo]);
+
+		await expect(result).rejects.toEqual({
+			filepath: 'Procfile',
+			error:
+				"404 ERROR: file 'Procfile' not found in 'Financial-Times/ebi'",
+			regex: undefined,
+			repository: 'Financial-Times/ebi',
+			search: 'web:',
+			type: 'error'
+		});
+	});
+});

--- a/test/lib/ebi/index.test.js
+++ b/test/lib/ebi/index.test.js
@@ -1,0 +1,19 @@
+const {
+	contentsSearch,
+	packageSearch,
+	packageEnginesSearch
+} = require('../../../lib/ebi');
+
+describe('ebi library', () => {
+	test('package exists', () => {
+		expect(contentsSearch).toBeTruthy();
+	});
+
+	test('package exists', () => {
+		expect(packageSearch).toBeTruthy();
+	});
+
+	test('packageEngines exists', () => {
+		expect(packageEnginesSearch).toBeTruthy();
+	});
+});

--- a/test/lib/ebi/package-engines-search.test.js
+++ b/test/lib/ebi/package-engines-search.test.js
@@ -1,0 +1,182 @@
+const nock = require('nock');
+
+const { base64EncodeObj } = require('../../helpers/base64');
+const {
+	packageEnginesSearch
+} = require('../../../lib/ebi/package-engines-search');
+
+let nockScope;
+let initialTTY;
+
+beforeAll(() => {
+	// Set isTTY to `true`, so that standard input is ignored
+	initialTTY = process.stdin.isTTY;
+	process.stdin.isTTY = true;
+});
+
+beforeEach(() => {
+	nockScope = nock('https://api.github.com/repos');
+});
+
+afterEach(() => {
+	nock.cleanAll();
+});
+
+afterAll(() => {
+	process.stdin.isTTY = initialTTY;
+});
+
+describe('packageEnginesSearch', () => {
+	let packageJson;
+	beforeEach(() => {
+		packageJson = {
+			engines: {
+				node: '~10.15.0'
+			}
+		};
+	});
+
+	test('empty search', async () => {
+		const repo = 'Financial-Times/ebi';
+		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
+			type: 'file',
+			content: base64EncodeObj(packageJson),
+			path: 'package.json'
+		});
+
+		const ebiSearch = packageEnginesSearch();
+		const [result] = await ebiSearch([repo]);
+
+		await expect(result).resolves.toEqual({
+			filepath: 'package.json',
+			fileContents: JSON.stringify(packageJson),
+			textSuffix: 'node@~10.15.0',
+			regex: undefined,
+			engines: packageJson.engines,
+			repository: 'Financial-Times/ebi',
+			search: undefined,
+			type: 'match'
+		});
+	});
+
+	test('search results found', async () => {
+		const repo = 'Financial-Times/ebi';
+		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
+			type: 'file',
+			content: base64EncodeObj(packageJson),
+			path: 'package.json'
+		});
+
+		const ebiSearch = packageEnginesSearch({
+			search: 'node'
+		});
+		const [result] = await ebiSearch([repo]);
+
+		await expect(result).resolves.toEqual({
+			filepath: 'package.json',
+			fileContents: JSON.stringify(packageJson),
+			textSuffix: 'node@~10.15.0',
+			regex: undefined,
+			engines: packageJson.engines,
+			repository: 'Financial-Times/ebi',
+			search: 'node',
+			type: 'match'
+		});
+	});
+
+	test('regex results found', async () => {
+		const repo = 'Financial-Times/ebi';
+		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
+			type: 'file',
+			content: base64EncodeObj(packageJson),
+			path: 'package.json'
+		});
+
+		const ebiSearch = packageEnginesSearch({
+			regex: 'n.de'
+		});
+		const [result] = await ebiSearch([repo]);
+
+		await expect(result).resolves.toEqual({
+			filepath: 'package.json',
+			fileContents: JSON.stringify(packageJson),
+			textSuffix: 'node@~10.15.0',
+			regex: 'n.de',
+			engines: packageJson.engines,
+			repository: 'Financial-Times/ebi',
+			search: undefined,
+			type: 'match'
+		});
+	});
+
+	test('regex used if search is present', async () => {
+		const repo = 'Financial-Times/ebi';
+		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
+			type: 'file',
+			content: base64EncodeObj(packageJson),
+			path: 'package.json'
+		});
+
+		const ebiSearch = packageEnginesSearch({
+			regex: 'n.de',
+			search: 'nope'
+		});
+		const [result] = await ebiSearch([repo]);
+
+		await expect(result).resolves.toEqual({
+			filepath: 'package.json',
+			fileContents: JSON.stringify(packageJson),
+			textSuffix: 'node@~10.15.0',
+			regex: 'n.de',
+			engines: packageJson.engines,
+			repository: 'Financial-Times/ebi',
+			search: 'nope',
+			type: 'match'
+		});
+	});
+
+	test('results not found', async () => {
+		const repo = 'Financial-Times/ebi';
+		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
+			type: 'file',
+			content: base64EncodeObj(packageJson),
+			path: 'package.json'
+		});
+
+		const ebiSearch = packageEnginesSearch({
+			search: 'something-else'
+		});
+		const [result] = await ebiSearch([repo]);
+
+		await expect(result).resolves.toEqual({
+			message:
+				"INFO: 'package.json' has no match for 'something-else' in 'Financial-Times/ebi'",
+			filepath: 'package.json',
+			fileContents: JSON.stringify(packageJson),
+			regex: undefined,
+			repository: 'Financial-Times/ebi',
+			search: 'something-else',
+			type: 'no-match'
+		});
+	});
+
+	test('file not found', async () => {
+		const repo = 'Financial-Times/ebi';
+		nockScope.get(`/${repo}/contents/package.json`).reply(404);
+
+		const ebiSearch = packageEnginesSearch({
+			search: 'ebi'
+		});
+		const [result] = await ebiSearch([repo]);
+
+		await expect(result).rejects.toEqual({
+			filepath: 'package.json',
+			error:
+				"404 ERROR: file 'package.json' not found in 'Financial-Times/ebi'",
+			regex: undefined,
+			repository: 'Financial-Times/ebi',
+			search: 'ebi',
+			type: 'error'
+		});
+	});
+});

--- a/test/lib/ebi/package-engines-search.test.js
+++ b/test/lib/ebi/package-engines-search.test.js
@@ -26,7 +26,7 @@ afterAll(() => {
 	process.stdin.isTTY = initialTTY;
 });
 
-describe('packageEnginesSearch', () => {
+describe('packageEnginesSearch resultsAsync', () => {
 	let packageJson;
 	beforeEach(() => {
 		packageJson = {
@@ -45,7 +45,8 @@ describe('packageEnginesSearch', () => {
 		});
 
 		const ebiSearch = packageEnginesSearch();
-		const [result] = await ebiSearch([repo]);
+		const { resultsAsync } = await ebiSearch([repo]);
+		const [result] = resultsAsync;
 
 		await expect(result).resolves.toEqual({
 			filepath: 'package.json',
@@ -70,7 +71,8 @@ describe('packageEnginesSearch', () => {
 		const ebiSearch = packageEnginesSearch({
 			search: 'node'
 		});
-		const [result] = await ebiSearch([repo]);
+		const { resultsAsync } = await ebiSearch([repo]);
+		const [result] = resultsAsync;
 
 		await expect(result).resolves.toEqual({
 			filepath: 'package.json',
@@ -95,7 +97,8 @@ describe('packageEnginesSearch', () => {
 		const ebiSearch = packageEnginesSearch({
 			regex: 'n.de'
 		});
-		const [result] = await ebiSearch([repo]);
+		const { resultsAsync } = await ebiSearch([repo]);
+		const [result] = resultsAsync;
 
 		await expect(result).resolves.toEqual({
 			filepath: 'package.json',
@@ -121,7 +124,8 @@ describe('packageEnginesSearch', () => {
 			regex: 'n.de',
 			search: 'nope'
 		});
-		const [result] = await ebiSearch([repo]);
+		const { resultsAsync } = await ebiSearch([repo]);
+		const [result] = resultsAsync;
 
 		await expect(result).resolves.toEqual({
 			filepath: 'package.json',
@@ -146,7 +150,8 @@ describe('packageEnginesSearch', () => {
 		const ebiSearch = packageEnginesSearch({
 			search: 'something-else'
 		});
-		const [result] = await ebiSearch([repo]);
+		const { resultsAsync } = await ebiSearch([repo]);
+		const [result] = resultsAsync;
 
 		await expect(result).resolves.toEqual({
 			message:
@@ -167,7 +172,8 @@ describe('packageEnginesSearch', () => {
 		const ebiSearch = packageEnginesSearch({
 			search: 'ebi'
 		});
-		const [result] = await ebiSearch([repo]);
+		const { resultsAsync } = await ebiSearch([repo]);
+		const [result] = resultsAsync;
 
 		await expect(result).rejects.toEqual({
 			filepath: 'package.json',
@@ -178,5 +184,119 @@ describe('packageEnginesSearch', () => {
 			search: 'ebi',
 			type: 'error'
 		});
+	});
+});
+
+describe('packageEnginesSearch getResults', () => {
+	let packageJson;
+	beforeEach(() => {
+		packageJson = {
+			engines: {
+				node: '~10.15.0'
+			}
+		};
+	});
+
+	test('search matches', async () => {
+		const repo = 'Financial-Times/ebi';
+		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
+			type: 'file',
+			content: base64EncodeObj(packageJson),
+			path: 'package.json'
+		});
+
+		const ebiSearch = packageEnginesSearch({
+			search: 'node'
+		});
+		const { getResults } = await ebiSearch([repo]);
+		const {
+			allResults,
+			searchMatches,
+			searchNoMatches,
+			searchErrors
+		} = await getResults();
+
+		const expectedResult = {
+			filepath: 'package.json',
+			fileContents: JSON.stringify(packageJson),
+			textSuffix: 'node@~10.15.0',
+			regex: undefined,
+			engines: packageJson.engines,
+			repository: 'Financial-Times/ebi',
+			search: 'node',
+			type: 'match'
+		};
+
+		expect(allResults).toEqual([expectedResult]);
+		expect(searchMatches).toEqual([expectedResult]);
+		expect(searchNoMatches).toEqual([]);
+		expect(searchErrors).toEqual([]);
+	});
+
+	test('search no matches', async () => {
+		const repo = 'Financial-Times/ebi';
+		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
+			type: 'file',
+			content: base64EncodeObj(packageJson),
+			path: 'package.json'
+		});
+
+		const ebiSearch = packageEnginesSearch({
+			search: 'something-else'
+		});
+		const { getResults } = await ebiSearch([repo]);
+		const {
+			allResults,
+			searchMatches,
+			searchNoMatches,
+			searchErrors
+		} = await getResults();
+
+		const expectedResult = {
+			filepath: 'package.json',
+			fileContents: JSON.stringify(packageJson),
+			message:
+				"INFO: 'package.json' has no match for 'something-else' in 'Financial-Times/ebi'",
+			regex: undefined,
+			repository: 'Financial-Times/ebi',
+			search: 'something-else',
+			type: 'no-match'
+		};
+
+		expect(allResults).toEqual([expectedResult]);
+		expect(searchMatches).toEqual([]);
+		expect(searchNoMatches).toEqual([expectedResult]);
+		expect(searchErrors).toEqual([]);
+	});
+
+	test('search errors', async () => {
+		const repo = 'Financial-Times/ebi';
+		nockScope.get(`/${repo}/contents/package.json`).reply(404);
+
+		const ebiSearch = packageEnginesSearch({
+			search: 'something'
+		});
+		const { getResults } = await ebiSearch([repo]);
+		const {
+			allResults,
+			searchMatches,
+			searchNoMatches,
+			searchErrors
+		} = await getResults();
+
+		const expectedResult = {
+			filepath: 'package.json',
+			error:
+				"404 ERROR: file 'package.json' not found in 'Financial-Times/ebi'",
+			regex: undefined,
+			repository: 'Financial-Times/ebi',
+			search: 'something',
+			type: 'error'
+		};
+
+		expect(allResults).toEqual([expectedResult]);
+		expect(searchMatches).toEqual([]);
+		expect(searchNoMatches).toEqual([]);
+		expect(searchErrors).toEqual([expectedResult]);
 	});
 });

--- a/test/lib/ebi/package-search.test.js
+++ b/test/lib/ebi/package-search.test.js
@@ -1,0 +1,170 @@
+const nock = require('nock');
+
+const { base64EncodeObj } = require('../../helpers/base64');
+const { packageSearch } = require('../../../lib/ebi/package-search');
+
+let nockScope;
+let initialTTY;
+
+beforeAll(() => {
+	// Set isTTY to `true`, so that standard input is ignored
+	initialTTY = process.stdin.isTTY;
+	process.stdin.isTTY = true;
+});
+
+beforeEach(() => {
+	nockScope = nock('https://api.github.com/repos');
+});
+
+afterEach(() => {
+	nock.cleanAll();
+});
+
+afterAll(() => {
+	process.stdin.isTTY = initialTTY;
+});
+
+describe('packageSearch', () => {
+	let packageJson;
+	beforeEach(() => {
+		packageJson = {
+			name: 'ebi'
+		};
+	});
+
+	test('empty search', async () => {
+		const repo = 'Financial-Times/ebi';
+		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
+			type: 'file',
+			content: base64EncodeObj(packageJson),
+			path: 'package.json'
+		});
+
+		const ebiSearch = packageSearch();
+		const [result] = await ebiSearch([repo]);
+
+		await expect(result).resolves.toEqual({
+			filepath: 'package.json',
+			fileContents: JSON.stringify(packageJson),
+			regex: undefined,
+			repository: 'Financial-Times/ebi',
+			search: undefined,
+			type: 'match'
+		});
+	});
+
+	test('search results found', async () => {
+		const repo = 'Financial-Times/ebi';
+		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
+			type: 'file',
+			content: base64EncodeObj(packageJson),
+			path: 'package.json'
+		});
+
+		const ebiSearch = packageSearch({
+			search: 'ebi'
+		});
+		const [result] = await ebiSearch([repo]);
+
+		await expect(result).resolves.toEqual({
+			filepath: 'package.json',
+			fileContents: JSON.stringify(packageJson),
+			regex: undefined,
+			repository: 'Financial-Times/ebi',
+			search: 'ebi',
+			type: 'match'
+		});
+	});
+
+	test('regex results found', async () => {
+		const repo = 'Financial-Times/ebi';
+		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
+			type: 'file',
+			content: base64EncodeObj(packageJson),
+			path: 'package.json'
+		});
+
+		const ebiSearch = packageSearch({
+			regex: 'e.i'
+		});
+		const [result] = await ebiSearch([repo]);
+
+		await expect(result).resolves.toEqual({
+			filepath: 'package.json',
+			fileContents: JSON.stringify(packageJson),
+			regex: 'e.i',
+			repository: 'Financial-Times/ebi',
+			search: undefined,
+			type: 'match'
+		});
+	});
+
+	test('regex used if search is present', async () => {
+		const repo = 'Financial-Times/ebi';
+		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
+			type: 'file',
+			content: base64EncodeObj(packageJson),
+			path: 'package.json'
+		});
+
+		const ebiSearch = packageSearch({
+			regex: 'e.i',
+			search: 'nope'
+		});
+		const [result] = await ebiSearch([repo]);
+
+		await expect(result).resolves.toEqual({
+			filepath: 'package.json',
+			fileContents: JSON.stringify(packageJson),
+			regex: 'e.i',
+			repository: 'Financial-Times/ebi',
+			search: 'nope',
+			type: 'match'
+		});
+	});
+
+	test('results not found', async () => {
+		const repo = 'Financial-Times/ebi';
+		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
+			type: 'file',
+			content: base64EncodeObj(packageJson),
+			path: 'package.json'
+		});
+
+		const ebiSearch = packageSearch({
+			search: 'something-else'
+		});
+		const [result] = await ebiSearch([repo]);
+
+		await expect(result).resolves.toEqual({
+			message:
+				"INFO: 'package.json' has no match for 'something-else' in 'Financial-Times/ebi'",
+			filepath: 'package.json',
+			fileContents: JSON.stringify(packageJson),
+			regex: undefined,
+			repository: 'Financial-Times/ebi',
+			search: 'something-else',
+			type: 'no-match'
+		});
+	});
+
+	test('file not found', async () => {
+		const repo = 'Financial-Times/ebi';
+		nockScope.get(`/${repo}/contents/package.json`).reply(404);
+
+		const ebiSearch = packageSearch({
+			search: 'ebi'
+		});
+		const [result] = await ebiSearch([repo]);
+
+		await expect(result).rejects.toEqual({
+			filepath: 'package.json',
+			error:
+				"404 ERROR: file 'package.json' not found in 'Financial-Times/ebi'",
+			regex: undefined,
+			repository: 'Financial-Times/ebi',
+			search: 'ebi',
+			type: 'error'
+		});
+	});
+});


### PR DESCRIPTION
Expose `ebi` 🦐  library, so that it can be used outside of the command line use case.

Fixes https://github.com/Financial-Times/ebi/issues/27

### Design decisions

* Suffix ebi commands with `Search`, so when they are imported you have the context. `package` is too generic and is a reserved word in JavaScript
* Use named exports, so it's more [explicit what is exported](https://humanwhocodes.com/blog/2019/01/stop-using-default-exports-javascript-module/)
* For the most part, cli tests should not change
* Using [JSDoc](https://jsdoc.app/) comments to document the library ([inspiration](https://medium.com/@trukrs/type-safe-javascript-with-jsdoc-7a2a63209b76))

### Notable changes

* [Breaking change] New `no-match` type for searches that don't match. Only changed on `--json` output
* Throw an error if `filepath` is missing in contents search (could bypass `yargs` check by doing `ebi contents ''`)

### TODO

* [x] Write integration tests
* [x] Move tests to the lib scope
* [x] Update readme
* [x] Example usage of library
* [x] ~[Bug] All promises need to be resolved before output to the console, make it stream again~ Nope not a problem
* [x] Simpler default of for getting search results