### PR TITLE
Only show results by default

### DIFF
--- a/lib/create-result.js
+++ b/lib/create-result.js
@@ -1,8 +1,4 @@
-const RESULT_TYPES = {
-	match: 'match',
-	noMatch: 'no-match',
-	error: 'error'
-};
+const { RESULT_TYPES } = require('./ebi/result-types');
 
 /**
  * Create result with initial data, then augment with `with*` functions
@@ -40,8 +36,6 @@ const withErrorMessage = message => {
 };
 
 module.exports = {
-	RESULT_TYPES,
-
 	createResult,
 	withMatch,
 	withMatchFileContents,

--- a/lib/ebi/ebi-log.js
+++ b/lib/ebi/ebi-log.js
@@ -1,10 +1,17 @@
 const { logText, logJson } = require('../log-result');
+const { RESULT_TYPES } = require('./result-types');
 const { withErrorMessage } = require('../create-result');
 
-const logOutput = ({ json, output }) => {
+const logOutput = ({ verbose, json, output }) => {
+	const { type } = output;
+
 	if (json) {
 		logJson(output);
 	} else {
+		// Ignore non-matches if not in verbose mode
+		if (type !== RESULT_TYPES.match && !verbose) {
+			return;
+		}
 		logText(output);
 	}
 };
@@ -16,18 +23,21 @@ const logOutput = ({ json, output }) => {
  * @param {boolean} json - whether to log in json or plain text
  * @param {array} arrayList - repository list
  */
-exports.ebiLog = ({ ebiSearch, json }) => repoList => {
+exports.ebiLog = ({ ebiSearch, json, verbose }) => repoList => {
 	return ebiSearch(repoList)
 		.then(({ resultsAsync }) => {
 			const results = resultsAsync.map(result => {
 				return result
-					.then(output => logOutput({ json, output }))
-					.catch(error => logOutput({ json, output: error }));
+					.then(output => logOutput({ verbose, json, output }))
+					.catch(error =>
+						logOutput({ verbose, json, output: error })
+					);
 			});
 			return Promise.all(results);
 		})
 		.catch(({ message }) =>
 			logOutput({
+				verbose,
 				json,
 				output: withErrorMessage(`ERROR: ${message}`)
 			})

--- a/lib/ebi/ebi-results.js
+++ b/lib/ebi/ebi-results.js
@@ -1,3 +1,4 @@
+const { RESULT_TYPES } = require('../../lib/ebi/result-types');
 const { createResult, withErrorMessage } = require('../../lib/create-result');
 
 /**
@@ -43,11 +44,15 @@ const getSyncResults = resultsAsync => async () => {
 		})
 	);
 
-	const searchMatches = allResults.filter(({ type }) => type === 'match');
-	const searchNoMatches = allResults.filter(
-		({ type }) => type === 'no-match'
+	const searchMatches = allResults.filter(
+		({ type }) => type === RESULT_TYPES.match
 	);
-	const searchErrors = allResults.filter(({ type }) => type === 'error');
+	const searchNoMatches = allResults.filter(
+		({ type }) => type === RESULT_TYPES.noMatch
+	);
+	const searchErrors = allResults.filter(
+		({ type }) => type === RESULT_TYPES.error
+	);
 
 	return {
 		allResults,

--- a/lib/ebi/result-types.js
+++ b/lib/ebi/result-types.js
@@ -1,0 +1,10 @@
+/**
+ * Ebi result types
+ *
+ * @type {Object<string, string>}
+ */
+exports.RESULT_TYPES = {
+	match: 'match',
+	noMatch: 'no-match',
+	error: 'error'
+};

--- a/lib/log-result.js
+++ b/lib/log-result.js
@@ -1,6 +1,6 @@
 /*eslint no-console: ["error", { allow: ["log", "error"] }] */
 
-const { RESULT_TYPES } = require('./create-result');
+const { RESULT_TYPES } = require('./ebi/result-types');
 
 const logText = result => {
 	const { type, repository, error, message, textSuffix } = result;

--- a/src/commands/contents.js
+++ b/src/commands/contents.js
@@ -8,7 +8,8 @@ const {
 	withLimit,
 	withRegex,
 	withJson,
-	withRepoList
+	withRepoList,
+	withVerbose
 } = require('./shared');
 
 exports.command = 'contents <filepath> [search] [repo..]';
@@ -22,7 +23,8 @@ exports.builder = yargs => {
 		withRegex,
 		withToken,
 		withLimit,
-		withRepoList
+		withRepoList,
+		withVerbose
 	]);
 	return baseConfig(yargs)
 		.positional('filepath', {
@@ -43,6 +45,7 @@ exports.handler = ({
 	regex,
 	limit,
 	json,
+	verbose,
 	repo: repoList
 } = {}) => {
 	return ebiLog({
@@ -53,6 +56,7 @@ exports.handler = ({
 			regex,
 			limit
 		}),
-		json
+		json,
+		verbose
 	})(repoList);
 };

--- a/src/commands/package-engines.js
+++ b/src/commands/package-engines.js
@@ -11,7 +11,8 @@ const {
 	withLimit,
 	withRegex,
 	withJson,
-	withRepoList
+	withRepoList,
+	withVerbose
 } = require('./shared');
 
 exports.command = 'package:engines [search] [repo..]';
@@ -24,7 +25,8 @@ exports.builder = yargs => {
 		withRegex,
 		withToken,
 		withLimit,
-		withRepoList
+		withRepoList,
+		withVerbose
 	]);
 	return baseConfig(yargs).positional('search', {
 		type: 'string',
@@ -38,6 +40,7 @@ exports.handler = function({
 	search,
 	regex,
 	json,
+	verbose,
 	repo: repoList
 } = {}) {
 	return ebiLog({
@@ -47,6 +50,7 @@ exports.handler = function({
 			regex,
 			limit
 		}),
-		json
+		json,
+		verbose
 	})(repoList);
 };

--- a/src/commands/package.js
+++ b/src/commands/package.js
@@ -9,7 +9,8 @@ const {
 	withLimit,
 	withRegex,
 	withJson,
-	withRepoList
+	withRepoList,
+	withVerbose
 } = require('./shared');
 
 exports.command = 'package [search] [repo..]';
@@ -22,7 +23,8 @@ exports.builder = yargs => {
 		withRegex,
 		withToken,
 		withLimit,
-		withRepoList
+		withRepoList,
+		withVerbose
 	]);
 	return baseConfig(yargs).positional('search', {
 		type: 'string',
@@ -37,6 +39,7 @@ exports.handler = function({
 	limit,
 	regex,
 	json,
+	verbose,
 	repo: repoList
 } = {}) {
 	return ebiLog({
@@ -46,6 +49,7 @@ exports.handler = function({
 			regex,
 			limit
 		}),
-		json
+		json,
+		verbose
 	})(repoList);
 };

--- a/src/commands/shared.js
+++ b/src/commands/shared.js
@@ -56,11 +56,19 @@ const withRepoList = yargs => {
 	});
 };
 
+const withVerbose = yargs => {
+	return yargs.option('verbose', {
+		type: 'boolean',
+		describe: 'Show all info and error messages. Ignored if outputting JSON'
+	});
+};
+
 module.exports = {
 	withEpilogue,
 	withLimit,
 	withToken,
 	withRegex,
 	withJson,
-	withRepoList
+	withRepoList,
+	withVerbose
 };

--- a/test/commands/contents.test.js
+++ b/test/commands/contents.test.js
@@ -5,6 +5,7 @@ const setupReadline = require('../helpers/setup-readline');
 const { base64Encode } = require('../helpers/base64');
 const { handler: contentsHandler } = require('../../src/commands/contents');
 const repo = 'Financial-Times/next-front-page';
+const { RESULT_TYPES } = require('../../lib/ebi/result-types');
 
 let nockScope;
 
@@ -82,7 +83,7 @@ describe('Log error for invalid repository', () => {
 
 		const log = JSON.parse(console.log.mock.calls[0][0]);
 		expect(log).toEqual({
-			type: 'error',
+			type: RESULT_TYPES.error,
 			filepath: 'Procfile',
 			search: 'node',
 			repository: invalidRepository,
@@ -302,7 +303,7 @@ describe('json output', () => {
 
 		const log = JSON.parse(console.log.mock.calls[0][0]);
 		expect(log).toEqual({
-			type: 'match',
+			type: RESULT_TYPES.match,
 			filepath: 'Procfile',
 			repository: repo,
 			fileContents: 'web: node 1234.js'
@@ -324,7 +325,7 @@ describe('json output', () => {
 
 		const log = JSON.parse(console.log.mock.calls[0][0]);
 		expect(log).toEqual({
-			type: 'match',
+			type: RESULT_TYPES.match,
 			filepath: 'Procfile',
 			search: 'node',
 			repository: repo,
@@ -347,7 +348,7 @@ describe('json output', () => {
 
 		const log = JSON.parse(console.log.mock.calls[0][0]);
 		expect(log).toEqual({
-			type: 'match',
+			type: RESULT_TYPES.match,
 			filepath: 'Procfile',
 			regex: 'node',
 			repository: repo,
@@ -374,7 +375,7 @@ describe('json output', () => {
 
 		const log = JSON.parse(console.log.mock.calls[0][0]);
 		expect(log).toEqual({
-			type: 'no-match',
+			type: RESULT_TYPES.noMatch,
 			filepath: 'Procfile',
 			search: 'something-else',
 			repository: repo,
@@ -394,7 +395,7 @@ describe('json output', () => {
 
 		const log = JSON.parse(console.log.mock.calls[0][0]);
 		expect(log).toEqual({
-			type: 'error',
+			type: RESULT_TYPES.error,
 			filepath: 'Procfile',
 			repository: repo,
 			error: expect.stringContaining('not found')

--- a/test/commands/package-engines.test.js
+++ b/test/commands/package-engines.test.js
@@ -6,6 +6,7 @@ const { base64EncodeObj } = require('../helpers/base64');
 const {
 	handler: packageEnginesHandler
 } = require('../../src/commands/package-engines');
+const { RESULT_TYPES } = require('../../lib/ebi/result-types');
 const repo = 'Financial-Times/next-front-page';
 
 let nockScope;
@@ -56,7 +57,7 @@ describe('Log error for invalid repository', () => {
 
 		const log = JSON.parse(console.log.mock.calls[0][0]);
 		expect(log).toEqual({
-			type: 'error',
+			type: RESULT_TYPES.error,
 			filepath: 'package.json',
 			repository: invalidRepository,
 			error: expect.stringContaining('invalid repository')
@@ -432,7 +433,7 @@ describe('json output', () => {
 
 		const log = JSON.parse(console.log.mock.calls[0][0]);
 		expect(log).toEqual({
-			type: 'match',
+			type: RESULT_TYPES.match,
 			textSuffix: 'node@~10.15.0',
 			filepath: 'package.json',
 			engines: packageJson.engines,
@@ -455,7 +456,7 @@ describe('json output', () => {
 
 		const log = JSON.parse(console.log.mock.calls[0][0]);
 		expect(log).toEqual({
-			type: 'match',
+			type: RESULT_TYPES.match,
 			textSuffix: 'node@~10.15.0',
 			filepath: 'package.json',
 			search: 'node',
@@ -479,7 +480,7 @@ describe('json output', () => {
 
 		const log = JSON.parse(console.log.mock.calls[0][0]);
 		expect(log).toEqual({
-			type: 'match',
+			type: RESULT_TYPES.match,
 			textSuffix: 'node@~10.15.0',
 			filepath: 'package.json',
 			regex: 'no.*',
@@ -503,7 +504,7 @@ describe('json output', () => {
 
 		const log = JSON.parse(console.log.mock.calls[0][0]);
 		expect(log).toEqual({
-			type: 'no-match',
+			type: RESULT_TYPES.noMatch,
 			filepath: 'package.json',
 			search: 'something-else',
 			fileContents: JSON.stringify(packageJson),
@@ -522,7 +523,7 @@ describe('json output', () => {
 
 		const log = JSON.parse(console.log.mock.calls[0][0]);
 		expect(log).toEqual({
-			type: 'error',
+			type: RESULT_TYPES.error,
 			filepath: 'package.json',
 			repository: repo,
 			error: expect.stringContaining('not found')

--- a/test/commands/package-engines.test.js
+++ b/test/commands/package-engines.test.js
@@ -36,12 +36,15 @@ afterEach(() => {
 	jest.resetAllMocks();
 });
 
-describe('Log error for invalid repository', () => {
+describe('Log error for invalid repository (with verbose flag)', () => {
 	const invalidRepository = 'something-invalid';
 
 	test(`'${invalidRepository}'`, async () => {
 		await initializeHandlerForStdin({
-			repos: [invalidRepository]
+			repos: [invalidRepository],
+			args: {
+				verbose: true
+			}
 		});
 
 		expect(console.error).toBeCalledWith(
@@ -85,7 +88,7 @@ describe('package:engines command handler', () => {
 		expect(console.error).not.toBeCalled();
 	});
 
-	test('repository not found', async () => {
+	test('repository not found (with verbose flag)', async () => {
 		const invalidRepo = 'Financial-Times/invalid';
 
 		nockScope.get(`/${invalidRepo}/contents/package.json`).reply(404, {
@@ -93,7 +96,8 @@ describe('package:engines command handler', () => {
 		});
 
 		await initializeHandlerForStdin({
-			repos: [invalidRepo]
+			repos: [invalidRepo],
+			args: { verbose: true }
 		});
 
 		expect(console.error).toBeCalledWith(
@@ -268,7 +272,7 @@ describe('package:engines command handler', () => {
 		expect(console.log).not.toBeCalled();
 	});
 
-	test('engines value not found in package.json logs to console error', async () => {
+	test('engines value not found in package.json logs to console error (with verbose flag)', async () => {
 		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
 			type: 'file',
 			content: base64EncodeObj({}),
@@ -276,7 +280,8 @@ describe('package:engines command handler', () => {
 		});
 
 		await initializeHandlerForStdin({
-			repos: [repo]
+			repos: [repo],
+			args: { verbose: true }
 		});
 
 		expect(console.error).toBeCalledWith(
@@ -284,7 +289,7 @@ describe('package:engines command handler', () => {
 		);
 	});
 
-	test('engines search not found in package.json, logs info message in console error', async () => {
+	test('engines search not found in package.json, logs info message in console error (with verbose flag)', async () => {
 		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
 			type: 'file',
 			content: base64EncodeObj({ engines: {} }),
@@ -292,7 +297,8 @@ describe('package:engines command handler', () => {
 		});
 
 		await initializeHandlerForStdin({
-			repos: [repo]
+			repos: [repo],
+			args: { verbose: true }
 		});
 
 		expect(console.error).toBeCalledWith(expect.stringContaining(repo));
@@ -301,7 +307,7 @@ describe('package:engines command handler', () => {
 		);
 	});
 
-	test('package.json not valid JSON', async () => {
+	test('package.json not valid JSON (with verbose flag)', async () => {
 		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
 			type: 'file',
 			content: 'something-invalid',
@@ -309,7 +315,8 @@ describe('package:engines command handler', () => {
 		});
 
 		await initializeHandlerForStdin({
-			repos: [repo]
+			repos: [repo],
+			args: { verbose: true }
 		});
 
 		expect(console.error).toBeCalledWith(
@@ -359,7 +366,7 @@ describe('package:engines command handler', () => {
 		expect(console.log).toBeCalledWith(expect.stringContaining(repo));
 	});
 
-	test('regex is not matched, logs error', async () => {
+	test('regex is not matched, logs error (with verbose flag)', async () => {
 		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
 			type: 'file',
 			content: base64EncodeObj({
@@ -373,7 +380,8 @@ describe('package:engines command handler', () => {
 		await initializeHandlerForStdin({
 			repos: [repo],
 			args: {
-				regex: 'something$'
+				regex: 'something$',
+				verbose: true
 			}
 		});
 
@@ -384,7 +392,7 @@ describe('package:engines command handler', () => {
 		expect(console.error).toBeCalledWith(expect.stringContaining(repo));
 	});
 
-	test('regex is used if search term also exists', async () => {
+	test('regex is used if search term also exists (with verbose flag)', async () => {
 		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
 			type: 'file',
 			content: base64EncodeObj({
@@ -399,7 +407,8 @@ describe('package:engines command handler', () => {
 			repos: [repo],
 			args: {
 				regex: 'something-else',
-				search: 'node'
+				search: 'node',
+				verbose: true
 			}
 		});
 

--- a/test/commands/package.test.js
+++ b/test/commands/package.test.js
@@ -4,6 +4,7 @@ const nock = require('nock');
 const setupReadline = require('../helpers/setup-readline');
 const { base64EncodeObj } = require('../helpers/base64');
 const { handler: packageHandler } = require('../../src/commands/package');
+const { RESULT_TYPES } = require('../../lib/ebi/result-types');
 const repo = 'Financial-Times/next-front-page';
 
 let nockScope;
@@ -55,7 +56,7 @@ describe('Log error for invalid repository', () => {
 
 		const log = JSON.parse(console.log.mock.calls[0][0]);
 		expect(log).toEqual({
-			type: 'error',
+			type: RESULT_TYPES.error,
 			filepath: 'package.json',
 			search: 'something',
 			repository: invalidRepository,
@@ -254,7 +255,7 @@ describe('json output', () => {
 
 		const log = JSON.parse(console.log.mock.calls[0][0]);
 		expect(log).toEqual({
-			type: 'match',
+			type: RESULT_TYPES.match,
 			filepath: 'package.json',
 			repository: repo,
 			fileContents: JSON.stringify(packageJson)
@@ -275,7 +276,7 @@ describe('json output', () => {
 
 		const log = JSON.parse(console.log.mock.calls[0][0]);
 		expect(log).toEqual({
-			type: 'match',
+			type: RESULT_TYPES.match,
 			filepath: 'package.json',
 			search: 'name',
 			repository: repo,
@@ -297,7 +298,7 @@ describe('json output', () => {
 
 		const log = JSON.parse(console.log.mock.calls[0][0]);
 		expect(log).toEqual({
-			type: 'match',
+			type: RESULT_TYPES.match,
 			filepath: 'package.json',
 			regex: 'front-.*',
 			repository: repo,
@@ -319,7 +320,7 @@ describe('json output', () => {
 
 		const log = JSON.parse(console.log.mock.calls[0][0]);
 		expect(log).toEqual({
-			type: 'no-match',
+			type: RESULT_TYPES.noMatch,
 			filepath: 'package.json',
 			search: 'something-else',
 			repository: repo,
@@ -338,7 +339,7 @@ describe('json output', () => {
 
 		const log = JSON.parse(console.log.mock.calls[0][0]);
 		expect(log).toEqual({
-			type: 'error',
+			type: RESULT_TYPES.error,
 			filepath: 'package.json',
 			repository: repo,
 			search: 'something',

--- a/test/commands/package.test.js
+++ b/test/commands/package.test.js
@@ -37,10 +37,10 @@ afterEach(() => {
 describe('Log error for invalid repository', () => {
 	const invalidRepository = 'something-invalid';
 
-	test(`'${invalidRepository}'`, async () => {
+	test(`'${invalidRepository}' (with verbose flag)`, async () => {
 		await initializeHandlerForStdin({
 			repos: [invalidRepository],
-			args: { search: 'something' }
+			args: { search: 'something', verbose: true }
 		});
 
 		expect(console.error).toBeCalledWith(
@@ -65,6 +65,36 @@ describe('Log error for invalid repository', () => {
 	});
 });
 
+describe('Do not log info and errors by default', () => {
+	const invalidRepository = 'something-invalid';
+
+	test(`for error'`, async () => {
+		await initializeHandlerForStdin({
+			repos: [invalidRepository],
+			args: { search: 'something' }
+		});
+
+		expect(console.log).not.toBeCalled();
+		expect(console.error).not.toBeCalled();
+	});
+
+	test(`for info message`, async () => {
+		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
+			type: 'file',
+			content: base64EncodeObj({}),
+			path: 'package.json'
+		});
+
+		await initializeHandlerForStdin({
+			repos: [repo],
+			args: { search: 'something-else' }
+		});
+
+		expect(console.log).not.toBeCalled();
+		expect(console.error).not.toBeCalled();
+	});
+});
+
 describe('package command handler', () => {
 	test('ignore empty string repositories', async () => {
 		await initializeHandlerForStdin({
@@ -85,7 +115,7 @@ describe('package command handler', () => {
 		expect(console.error).not.toBeCalled();
 	});
 
-	test('repository not found', async () => {
+	test('repository not found (with verbose flag)', async () => {
 		const invalidRepo = 'Financial-Times/invalid';
 		nockScope.get(`/${invalidRepo}/contents/package.json`).reply(404, {
 			message: 'Not Found'
@@ -93,7 +123,7 @@ describe('package command handler', () => {
 
 		await initializeHandlerForStdin({
 			repos: [invalidRepo],
-			args: { search: 'something' }
+			args: { search: 'something', verbose: true }
 		});
 
 		expect(console.error).toBeCalledWith(
@@ -152,7 +182,7 @@ describe('package command handler', () => {
 		expect(console.log).toBeCalledWith('Financial-Times/next-front-page');
 	});
 
-	test('<search> value not found, logs info message in console error', async () => {
+	test('<search> value not found, logs info message in console error (with verbose flag)', async () => {
 		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
 			type: 'file',
 			content: base64EncodeObj({
@@ -163,7 +193,7 @@ describe('package command handler', () => {
 
 		await initializeHandlerForStdin({
 			repos: [repo],
-			args: { search: 'something-else' }
+			args: { search: 'something-else', verbose: true }
 		});
 
 		expect(console.error).toBeCalledWith(expect.stringContaining(repo));
@@ -192,7 +222,7 @@ describe('package command handler', () => {
 		expect(console.log).toBeCalledWith(expect.stringContaining(repo));
 	});
 
-	test('regex is not matched, logs error', async () => {
+	test('regex is not matched, logs error (with verbose flag)', async () => {
 		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
 			type: 'file',
 			content: base64EncodeObj({
@@ -203,7 +233,7 @@ describe('package command handler', () => {
 
 		await initializeHandlerForStdin({
 			repos: [repo],
-			args: { regex: 'something$' }
+			args: { regex: 'something$', verbose: true }
 		});
 
 		expect(console.log).not.toBeCalled();
@@ -213,7 +243,7 @@ describe('package command handler', () => {
 		expect(console.error).toBeCalledWith(expect.stringContaining(repo));
 	});
 
-	test('regex is used if search term also exists', async () => {
+	test('regex is used if search term also exists (with verbose flag)', async () => {
 		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
 			type: 'file',
 			content: base64EncodeObj({
@@ -224,7 +254,7 @@ describe('package command handler', () => {
 
 		await initializeHandlerForStdin({
 			repos: [repo],
-			args: { regex: 'something-else', search: 'front' }
+			args: { regex: 'something-else', search: 'front', verbose: true }
 		});
 
 		expect(console.error).toBeCalledWith(

--- a/test/lib/ebi/contents-search.test.js
+++ b/test/lib/ebi/contents-search.test.js
@@ -2,6 +2,7 @@ const nock = require('nock');
 
 const { base64Encode } = require('../../helpers/base64');
 const { contentsSearch } = require('../../../lib/ebi/contents-search');
+const { RESULT_TYPES } = require('../../../lib/ebi/result-types');
 
 let nockScope;
 let initialTTY;
@@ -53,7 +54,7 @@ describe('contentsSearch resultsAsync', () => {
 			regex: undefined,
 			repository: 'Financial-Times/ebi',
 			search: 'web:',
-			type: 'match'
+			type: RESULT_TYPES.match
 		});
 	});
 
@@ -78,7 +79,7 @@ describe('contentsSearch resultsAsync', () => {
 			regex: 'w..:',
 			repository: 'Financial-Times/ebi',
 			search: undefined,
-			type: 'match'
+			type: RESULT_TYPES.match
 		});
 	});
 
@@ -104,7 +105,7 @@ describe('contentsSearch resultsAsync', () => {
 			regex: 'w..:',
 			repository: 'Financial-Times/ebi',
 			search: 'nope',
-			type: 'match'
+			type: RESULT_TYPES.match
 		});
 	});
 
@@ -131,7 +132,7 @@ describe('contentsSearch resultsAsync', () => {
 			regex: undefined,
 			repository: 'Financial-Times/ebi',
 			search: 'node',
-			type: 'no-match'
+			type: RESULT_TYPES.noMatch
 		});
 	});
 
@@ -153,7 +154,7 @@ describe('contentsSearch resultsAsync', () => {
 			regex: undefined,
 			repository: 'Financial-Times/ebi',
 			search: 'web:',
-			type: 'error'
+			type: RESULT_TYPES.error
 		});
 	});
 });
@@ -185,7 +186,7 @@ describe('contentsSearch getResults', () => {
 			regex: undefined,
 			repository: 'Financial-Times/ebi',
 			search: 'web:',
-			type: 'match'
+			type: RESULT_TYPES.match
 		};
 
 		expect(allResults).toEqual([expectedResult]);
@@ -222,7 +223,7 @@ describe('contentsSearch getResults', () => {
 			message:
 				"INFO: 'Procfile' has no match for 'something-else' in 'Financial-Times/ebi'",
 			search: 'something-else',
-			type: 'no-match'
+			type: RESULT_TYPES.noMatch
 		};
 
 		expect(allResults).toEqual([expectedResult]);
@@ -254,7 +255,7 @@ describe('contentsSearch getResults', () => {
 			error:
 				"404 ERROR: file 'Procfile' not found in 'Financial-Times/ebi'",
 			search: 'something',
-			type: 'error'
+			type: RESULT_TYPES.error
 		};
 
 		expect(allResults).toEqual([expectedResult]);

--- a/test/lib/ebi/package-engines-search.test.js
+++ b/test/lib/ebi/package-engines-search.test.js
@@ -4,6 +4,7 @@ const { base64EncodeObj } = require('../../helpers/base64');
 const {
 	packageEnginesSearch
 } = require('../../../lib/ebi/package-engines-search');
+const { RESULT_TYPES } = require('../../../lib/ebi/result-types');
 
 let nockScope;
 let initialTTY;
@@ -56,7 +57,7 @@ describe('packageEnginesSearch resultsAsync', () => {
 			engines: packageJson.engines,
 			repository: 'Financial-Times/ebi',
 			search: undefined,
-			type: 'match'
+			type: RESULT_TYPES.match
 		});
 	});
 
@@ -82,7 +83,7 @@ describe('packageEnginesSearch resultsAsync', () => {
 			engines: packageJson.engines,
 			repository: 'Financial-Times/ebi',
 			search: 'node',
-			type: 'match'
+			type: RESULT_TYPES.match
 		});
 	});
 
@@ -108,7 +109,7 @@ describe('packageEnginesSearch resultsAsync', () => {
 			engines: packageJson.engines,
 			repository: 'Financial-Times/ebi',
 			search: undefined,
-			type: 'match'
+			type: RESULT_TYPES.match
 		});
 	});
 
@@ -135,7 +136,7 @@ describe('packageEnginesSearch resultsAsync', () => {
 			engines: packageJson.engines,
 			repository: 'Financial-Times/ebi',
 			search: 'nope',
-			type: 'match'
+			type: RESULT_TYPES.match
 		});
 	});
 
@@ -161,7 +162,7 @@ describe('packageEnginesSearch resultsAsync', () => {
 			regex: undefined,
 			repository: 'Financial-Times/ebi',
 			search: 'something-else',
-			type: 'no-match'
+			type: RESULT_TYPES.noMatch
 		});
 	});
 
@@ -182,7 +183,7 @@ describe('packageEnginesSearch resultsAsync', () => {
 			regex: undefined,
 			repository: 'Financial-Times/ebi',
 			search: 'ebi',
-			type: 'error'
+			type: RESULT_TYPES.error
 		});
 	});
 });
@@ -224,7 +225,7 @@ describe('packageEnginesSearch getResults', () => {
 			engines: packageJson.engines,
 			repository: 'Financial-Times/ebi',
 			search: 'node',
-			type: 'match'
+			type: RESULT_TYPES.match
 		};
 
 		expect(allResults).toEqual([expectedResult]);
@@ -260,7 +261,7 @@ describe('packageEnginesSearch getResults', () => {
 			regex: undefined,
 			repository: 'Financial-Times/ebi',
 			search: 'something-else',
-			type: 'no-match'
+			type: RESULT_TYPES.noMatch
 		};
 
 		expect(allResults).toEqual([expectedResult]);
@@ -291,7 +292,7 @@ describe('packageEnginesSearch getResults', () => {
 			regex: undefined,
 			repository: 'Financial-Times/ebi',
 			search: 'something',
-			type: 'error'
+			type: RESULT_TYPES.error
 		};
 
 		expect(allResults).toEqual([expectedResult]);

--- a/test/lib/ebi/package-search.test.js
+++ b/test/lib/ebi/package-search.test.js
@@ -2,6 +2,7 @@ const nock = require('nock');
 
 const { base64EncodeObj } = require('../../helpers/base64');
 const { packageSearch } = require('../../../lib/ebi/package-search');
+const { RESULT_TYPES } = require('../../../lib/ebi/result-types');
 
 let nockScope;
 let initialTTY;
@@ -50,7 +51,7 @@ describe('packageSearch resultsAsync', () => {
 			regex: undefined,
 			repository: 'Financial-Times/ebi',
 			search: undefined,
-			type: 'match'
+			type: RESULT_TYPES.match
 		});
 	});
 
@@ -74,7 +75,7 @@ describe('packageSearch resultsAsync', () => {
 			regex: undefined,
 			repository: 'Financial-Times/ebi',
 			search: 'ebi',
-			type: 'match'
+			type: RESULT_TYPES.match
 		});
 	});
 
@@ -98,7 +99,7 @@ describe('packageSearch resultsAsync', () => {
 			regex: 'e.i',
 			repository: 'Financial-Times/ebi',
 			search: undefined,
-			type: 'match'
+			type: RESULT_TYPES.match
 		});
 	});
 
@@ -123,7 +124,7 @@ describe('packageSearch resultsAsync', () => {
 			regex: 'e.i',
 			repository: 'Financial-Times/ebi',
 			search: 'nope',
-			type: 'match'
+			type: RESULT_TYPES.match
 		});
 	});
 
@@ -149,7 +150,7 @@ describe('packageSearch resultsAsync', () => {
 			regex: undefined,
 			repository: 'Financial-Times/ebi',
 			search: 'something-else',
-			type: 'no-match'
+			type: RESULT_TYPES.noMatch
 		});
 	});
 
@@ -170,7 +171,7 @@ describe('packageSearch resultsAsync', () => {
 			regex: undefined,
 			repository: 'Financial-Times/ebi',
 			search: 'ebi',
-			type: 'error'
+			type: RESULT_TYPES.error
 		});
 	});
 });
@@ -208,7 +209,7 @@ describe('packageSearch getResults', () => {
 			regex: undefined,
 			repository: 'Financial-Times/ebi',
 			search: 'ebi',
-			type: 'match'
+			type: RESULT_TYPES.match
 		};
 
 		expect(allResults).toEqual([expectedResult]);
@@ -244,7 +245,7 @@ describe('packageSearch getResults', () => {
 			regex: undefined,
 			repository: 'Financial-Times/ebi',
 			search: 'something-else',
-			type: 'no-match'
+			type: RESULT_TYPES.noMatch
 		};
 
 		expect(allResults).toEqual([expectedResult]);
@@ -275,7 +276,7 @@ describe('packageSearch getResults', () => {
 			regex: undefined,
 			repository: 'Financial-Times/ebi',
 			search: 'something',
-			type: 'error'
+			type: RESULT_TYPES.error
 		};
 
 		expect(allResults).toEqual([expectedResult]);


### PR DESCRIPTION
Only show results by default and add a `--verbose` flag to show `INFO` and `ERROR` output.

This is what happens with the changes:

```
$ cat repos.txt |  ebi package "cypress"
org/found-repo

$ cat repos.txt |  ebi package "cypress" --verbose
INFO: 'package.json' has no match for 'cypress' in 'org/repo1'
404 ERROR: file 'package.json' not found in 'org/repo2'
org/found-repo
```

Notes:

* Only affects text output on the command line
* JSON (`--json`) output is unchanged, and `--verbose` doesn't do anything here
* Library usage is unchanged, as it only affects the command line logging layer

Fixes https://github.com/Financial-Times/ebi/issues/110