### PR TITLE
Support a dot in repo names.

### DIFF
--- a/lib/github-helpers.js
+++ b/lib/github-helpers.js
@@ -1,4 +1,4 @@
-const GITHUB_REPO_REGEX = /^(?:\S*github\.com(?:\/|:))?([\w-]+)\/([\w-]+)/;
+const GITHUB_REPO_REGEX = /^(?:\S*github\.com(?:\/|:))?([\w-]+)\/([\w-\.]+)/;
 
 /**
  * Array of repo string patterns supported by `extractOwnerAndRepo`.
@@ -6,14 +6,14 @@ const GITHUB_REPO_REGEX = /^(?:\S*github\.com(?:\/|:))?([\w-]+)\/([\w-]+)/;
  * @type {Array<string>}
  */
 const SUPPORTED_REPO_STRING_PATTERNS = [
-	'github-organization/github-repo-name',
-	'github.com/github-organization/github-repo-name',
-	'subdomain.github.com/github-organization/github-repo-name',
-	'https://github.com/github-organization/github-repo-name',
-	'https://github.com/github-organization/github-repo-name/blob/master',
-	'https://github.com/github-organization/github-repo-name.git',
-	'git+https://github.com/github-organization/github-repo-name.git',
-	'git@github.com:github-organization/github-repo-name.git'
+	'github-organization/github-repo.name',
+	'github.com/github-organization/github-repo.name',
+	'subdomain.github.com/github-organization/github-repo.name',
+	'https://github.com/github-organization/github-repo.name',
+	'https://github.com/github-organization/github-repo.name/blob/master',
+	'https://github.com/github-organization/github-repo.name.git',
+	'git+https://github.com/github-organization/github-repo.name.git',
+	'git@github.com:github-organization/github-repo.name.git'
 ];
 
 /**
@@ -24,6 +24,9 @@ const SUPPORTED_REPO_STRING_PATTERNS = [
  * @returns {object} - Properties: owner, repo
  */
 function extractOwnerAndRepo(githubRepoString) {
+	// Remove trailing .git extension
+	githubRepoString = githubRepoString.replace(/.git$/, '');
+	// Match owner and repo
 	const matches = GITHUB_REPO_REGEX.exec(githubRepoString);
 
 	if (matches === null) {

--- a/test/lib/github-helpers.test.js
+++ b/test/lib/github-helpers.test.js
@@ -4,7 +4,7 @@ const {
 } = require('../../lib/github-helpers');
 
 const expectedOwner = 'github-organization';
-const expectedRepo = 'github-repo-name';
+const expectedRepo = 'github-repo.name';
 
 const supportedRepoStrings = SUPPORTED_REPO_STRING_PATTERNS;
 


### PR DESCRIPTION
Currently Ebi parses https://github.com/financial-times/ft.com-cdn
as https://github.com/financial-times/ft, which redirects and returns
files from https://github.com/financial-times/fta

This commit updates `GITHUB_REPO_REGEX` to match dots in the repo
name. This however means `.git` is also matched, so `.git` is
removed first as part of the `extractOwnerAndRepo` method.

_Note: My previous attempt to do everything in a regex, without removing
`.git` first didn't go great. I ended up with the repo name either being
in group 2 or 3:
`^(?:\S*github\.com(?:\/|:))?([\w-]+)\/(?:([\w-\.]+)(?:\.git)|([\w-\.]+))`_