### PR TITLE
chore(npm): updating lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4200,9 +4200,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.13",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.13.tgz",
-			"integrity": "sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA=="
+			"version": "4.17.20",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
 		},
 		"lodash.get": {
 			"version": "4.4.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 	"dependencies": {
 		"@octokit/plugin-throttling": "^2.4.0",
 		"@octokit/rest": "^16.15.0",
-		"lodash": "^4.17.11",
+		"lodash": "^4.17.20",
 		"nock": "^11.0.0",
 		"update-notifier": "^4.0.0",
 		"yargs": "^14.0.0"


### PR DESCRIPTION
#### Reference
- https://financialtimes.atlassian.net/browse/CPP-363

#### Note
- The `lodash` update has fixed both `H` marked vulnerabilities

#### Random picture of cat
![image](https://user-images.githubusercontent.com/102233/98684681-5ed75380-235e-11eb-8ad2-fdbd51786172.png)
