### PR TITLE
CPP-442 Upgrade GitHub repos from `master` to `main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 🦐 Ebi: GitHub repositories contents search
 
-<a href="https://circleci.com/gh/Financial-Times/ebi/tree/master">
-	<img alt="Build Status" src="https://circleci.com/gh/Financial-Times/ebi/tree/master.svg?style=svg">
+<a href="https://circleci.com/gh/Financial-Times/ebi/tree/main">
+	<img alt="Build Status" src="https://circleci.com/gh/Financial-Times/ebi/tree/main.svg?style=svg">
 </a>
 
 Searches files within GitHub repositories. It can be used as a command line tool or a library.

--- a/lib/github-helpers.js
+++ b/lib/github-helpers.js
@@ -10,7 +10,7 @@ const SUPPORTED_REPO_STRING_PATTERNS = [
 	'github.com/github-organization/github-repo.name',
 	'subdomain.github.com/github-organization/github-repo.name',
 	'https://github.com/github-organization/github-repo.name',
-	'https://github.com/github-organization/github-repo.name/blob/master',
+	'https://github.com/github-organization/github-repo.name/blob/main',
 	'https://github.com/github-organization/github-repo.name.git',
 	'git+https://github.com/github-organization/github-repo.name.git',
 	'git@github.com:github-organization/github-repo.name.git'


### PR DESCRIPTION
[Ticket CPP-442 Upgrade GitHub repos from `master` to `main`](https://financialtimes.atlassian.net/browse/CPP-442)

This PR removed references to `master` so that it aligns to the central branch change to `main`