### PR TITLE
CPP-642 migrate from circleci/* to cimg/*

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
     circleci-node:
         docker:
-            - image: circleci/node:12
+            - image: cimg/node:12.22
         working_directory: ~/project/build-node
 
 commands:


### PR DESCRIPTION
These images will be EOL from Dec 31st, and we should migrate to the modern cimg/* equivalents.