### PR TITLE
Also search for Volta object when searching for engines value

### DIFF
--- a/lib/ebi/package-engines-search.js
+++ b/lib/ebi/package-engines-search.js
@@ -30,7 +30,7 @@ const getJson = ({ filepath, repository }) => data => {
 };
 
 const throwIfNoEngines = ({ filepath, repository }) => (json = {}) => {
-	const { engines } = json;
+	const engines = json.engines || json.volta;
 	if (!engines) {
 		throw new Error(
 			`INFO: engines field not found in '${filepath}' in '${repository}'`


### PR DESCRIPTION
Currently in the `packages-search-engine function` only the `engines` field is searched for. Sometimes repos use a "Volta" field to specify the engine and npm version for the app (at the moment 12 repos do this), so let's also search for that a return a result if either are present