### PR TITLE
Update to Node 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
     working_directory: ~/project/build-node
     parameters:
       node-version:
-        default: "16.14"
+        default: "18.16"
         type: string
 
 commands:
@@ -28,8 +28,7 @@ references:
 
   workspace_root: &workspace_root ~/project
 
-  attach_workspace:
-    &attach_workspace
+  attach_workspace: &attach_workspace
     attach_workspace:
       at: *workspace_root
 
@@ -37,20 +36,17 @@ references:
   # Filters
   #
 
-  filters_only_renovate_nori:
-    &filters_only_renovate_nori
+  filters_only_renovate_nori: &filters_only_renovate_nori
     branches:
       only: /(^renovate-.*|^nori\/.*)/
 
-  filters_branch_build_renovate_nori:
-    &filters_branch_build_renovate_nori
+  filters_branch_build_renovate_nori: &filters_branch_build_renovate_nori
     tags:
       ignore: /.*/
     branches:
       ignore: /(^renovate-.*|^nori\/.*)/
 
-  filters_release_package_build:
-    &filters_release_package_build
+  filters_release_package_build: &filters_release_package_build
     tags:
       only:
         - /^v\d+\.\d+\.\d+(\-\w+\.\d+)?$/
@@ -62,13 +58,9 @@ jobs:
   build-node:
     executor: circleci-node
     parameters:
-      node-version:
-        default: "16.14"
-        type: string
+      node-version: [ "16.20", "18.16" ]
     steps:
       - checkout
-      - node/install-npm:
-          version: "7"
       - npm-install
       - persist_to_workspace:
           root: *workspace_root
@@ -77,9 +69,7 @@ jobs:
   test-node:
     executor: circleci-node
     parameters:
-      node-version:
-        default: "16.14"
-        type: string
+      node-version: [ "16.20", "18.16" ]
     steps:
       - *attach_workspace
       - run:
@@ -89,9 +79,7 @@ jobs:
   publish:
     executor: circleci-node
     parameters:
-      node-version:
-        default: "16.14"
-        type: string
+      node-version: [ "16.20", "18.16" ]
     steps:
       - *attach_workspace
       - run:
@@ -125,14 +113,14 @@ workflows:
           name: build-node-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.20", "18.16" ]
       - test-node:
           requires:
             - build-node-v<< matrix.node-version >>
           name: test-node-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.20", "18.16" ]
 
   renovate-nori-build-test:
     jobs:
@@ -146,14 +134,14 @@ workflows:
           name: build-node-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.20", "18.16" ]
       - test-node:
           requires:
             - build-node-v<< matrix.node-version >>
           name: test-node-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.20", "18.16" ]
 
   build-test-publish:
     jobs:
@@ -163,7 +151,7 @@ workflows:
           name: build-node-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.20", "18.16" ]
       - test-node:
           filters:
             <<: *filters_release_package_build
@@ -172,10 +160,10 @@ workflows:
           name: test-node-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.20", "18.16" ]
       - publish:
           context: npm-publish-token
           filters:
             <<: *filters_release_package_build
           requires:
-            - test-node-v16.14
+            - test-node-v18.16

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,8 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "ebi",
       "version": "0.0.0",
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/plugin-throttling": "^3.3.4",
@@ -29,8 +29,8 @@
         "prettier": "1.17.0"
       },
       "engines": {
-        "node": "16.x",
-        "npm": "7.x || 8.x"
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "eslint-check": "eslint --print-config . | eslint-config-prettier-check",
     "test": "npm run lint && npm run unit-test",
     "unit-test": "jest",
-    "unit-test:watch": "jest --watch",
-    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
+    "unit-test:watch": "jest --watch"
   },
   "repository": {
     "type": "git",
@@ -37,8 +36,8 @@
   },
   "homepage": "https://github.com/Financial-Times/ebi#readme",
   "engines": {
-    "node": "16.x",
-    "npm": "7.x || 8.x"
+    "node": "16.x || 18.x",
+    "npm": "7.x || 8.x || 9.x"
   },
   "husky": {
     "hooks": {
@@ -63,7 +62,6 @@
     "prettier": "1.17.0"
   },
   "volta": {
-    "node": "16.14.1",
-    "npm": "7.20.2"
+    "node": "18.16.0"
   }
 }


### PR DESCRIPTION
Automatically ran via Platforms' [migration script](https://github.com/Financial-Times/platform-scripts/blob/464d56876a27742dbdee2713a31266cc268ebfe3/upgrade-node-18/upgrade-node-18.ts)