### PR TITLE
Delete .github/settings.yml

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,3 +1,0 @@
-_extends: github-apps-config-next
-repository:
-    has_wiki: true


### PR DESCRIPTION
this controls the Probot Settings app, which we're phasing out in Customer Products